### PR TITLE
fix: dont attempt pessimistic on NotSerializableException

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
@@ -226,6 +226,7 @@ public class SessionSerializer
         long start = System.currentTimeMillis();
         long timeout = start + optimisticSerializationTimeoutMs;
         String clusterKey = getClusterKey(attributes);
+        boolean unrecoverableError = false;
         try {
             getLogger().debug(
                     "Optimistic serialization of session {} with distributed key {} started",
@@ -242,18 +243,26 @@ public class SessionSerializer
                     return;
                 }
             }
+        } catch (NotSerializableException e) {
+            getLogger().trace(
+                    "Optimistic serialization of session {} with distributed key {} failed,"
+                            + " some attribute is not serializable. Giving up immediately since the error is not recoverable",
+                    sessionId, clusterKey, e);
+            unrecoverableError = true;
         } catch (IOException e) {
             getLogger().warn(
                     "Optimistic serialization of session {} with distributed key {} failed",
                     sessionId, clusterKey, e);
         }
 
-        // Serializing using optimistic locking failed for a long time so be
-        // pessimistic
-        // and get it done
         pending.remove(sessionId);
-        whenSerialized
-                .accept(serializePessimisticLocking(sessionId, attributes));
+        SessionInfo sessionInfo = null;
+        if (!unrecoverableError) { // NOSONAR
+            // Serializing using optimistic locking failed for a long time so be
+            // pessimistic and get it done
+            sessionInfo = serializePessimisticLocking(sessionId, attributes);
+        }
+        whenSerialized.accept(sessionInfo);
     }
 
     private SessionInfo serializePessimisticLocking(String sessionId,
@@ -332,10 +341,6 @@ public class SessionSerializer
                     + " with distributed key " + clusterKey, attributes);
             return info;
         } catch (NotSerializableException e) {
-            getLogger().trace(
-                    "Optimistic serialization of session {} with distributed key {} failed,"
-                            + " some attribute is not serializable. Giving up immediately since the error is not recoverable",
-                    sessionId, clusterKey, e);
             throw e;
         } catch (Exception e) {
             getLogger().trace(

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
@@ -244,7 +244,7 @@ public class SessionSerializer
                 }
             }
         } catch (NotSerializableException e) {
-            getLogger().trace(
+            getLogger().error(
                     "Optimistic serialization of session {} with distributed key {} failed,"
                             + " some attribute is not serializable. Giving up immediately since the error is not recoverable",
                     sessionId, clusterKey, e);


### PR DESCRIPTION
## Description

When optimistic serialization fails with NotSerializableException it does not make sense to attemp pessimistic approach, since it will fail with the same error.

Fixes #49

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
