### PR TITLE
fix: use vaadin-maven-plugin in production profile

### DIFF
--- a/kubernetes-kit-demo/pom.xml
+++ b/kubernetes-kit-demo/pom.xml
@@ -111,7 +111,7 @@
                 <plugins>
                     <plugin>
                         <groupId>com.vaadin</groupId>
-                        <artifactId>flow-maven-plugin</artifactId>
+                        <artifactId>vaadin-maven-plugin</artifactId>
                         <version>${flow.version}</version>
                         <executions>
                             <execution>


### PR DESCRIPTION
Production profile used flow-maven-plugin instead of vaadin-maven-plugin and for this reason, the final artifact had not the productionMode flag set to true
