### PR TITLE
fix: Remove namespace canary from the k8s manifests

### DIFF
--- a/kubernetes-kit-demo/deployment/app-v1.yaml
+++ b/kubernetes-kit-demo/deployment/app-v1.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubernetes-kit-demo-v1
-  namespace: canary
 spec:
   replicas: 4
   selector:
@@ -31,7 +30,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kubernetes-kit-demo-v1
-  namespace: canary
 spec:
   selector:
     app: kubernetes-kit-demo

--- a/kubernetes-kit-demo/deployment/app-v2.yaml
+++ b/kubernetes-kit-demo/deployment/app-v2.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubernetes-kit-demo-v2
-  namespace: canary
 spec:
   replicas: 4
   selector:
@@ -31,7 +30,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kubernetes-kit-demo-v2
-  namespace: canary
 spec:
   selector:
     app: kubernetes-kit-demo

--- a/kubernetes-kit-demo/deployment/hazelcast.yaml
+++ b/kubernetes-kit-demo/deployment/hazelcast.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kubernetes-kit-hazelcast-service
-  namespace: canary
 spec:
   selector:
     app: kubernetes-kit-demo

--- a/kubernetes-kit-demo/deployment/ingress-v1-add-header.yaml
+++ b/kubernetes-kit-demo/deployment/ingress-v1-add-header.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: kubernetes-kit-demo
-  namespace: canary
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"

--- a/kubernetes-kit-demo/deployment/ingress-v1.yaml
+++ b/kubernetes-kit-demo/deployment/ingress-v1.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: kubernetes-kit-demo
-  namespace: canary
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"

--- a/kubernetes-kit-demo/deployment/ingress-v2-use-canary.yaml
+++ b/kubernetes-kit-demo/deployment/ingress-v2-use-canary.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: kubernetes-kit-demo-canary
-  namespace: canary
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"

--- a/kubernetes-kit-demo/deployment/ingress-v2.yaml
+++ b/kubernetes-kit-demo/deployment/ingress-v2.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: kubernetes-kit-demo
-  namespace: canary
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"

--- a/kubernetes-kit-demo/deployment/redis.yaml
+++ b/kubernetes-kit-demo/deployment/redis.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubernetes-kit-redis
-  namespace: canary
 spec:
   replicas: 1
   selector:
@@ -23,7 +22,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kubernetes-kit-redis-service
-  namespace: canary
 spec:
   selector:
     app: kubernetes-kit-redis


### PR DESCRIPTION
## Description

Remove the namespace `canary` from the k8s manifests. If the namespace is not specified the `default` is used.
With this change the to code will be up-to-date with the README and the documentation.

Fixes #57 

## Type of change

- [x] Bugfix
- [ ] Feature