### PR TITLE
fix: clear debug tool results when serialization starts

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/TransientInjectableObjectInputStream.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/TransientInjectableObjectInputStream.java
@@ -154,6 +154,9 @@ public class TransientInjectableObjectInputStream extends ObjectInputStream {
     @SuppressWarnings("unchecked")
     public <T> T readWithTransients()
             throws IOException, ClassNotFoundException {
+        if (injector instanceof DebugMode) {
+            ((DebugMode) injector).onDeserializationStart();
+        }
         Object out = readObject();
         // Read TransientAwareHolder to inject transient fields
         List<TransientAwareHolder> holders = (List<TransientAwareHolder>) readObject();

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/TransientInjectableObjectOutputStream.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/TransientInjectableObjectOutputStream.java
@@ -170,6 +170,9 @@ public class TransientInjectableObjectOutputStream extends ObjectOutputStream {
     public void writeWithTransients(Object object) throws IOException {
         inspected.clear();
         tracking.clear();
+        if (inspector instanceof DebugMode) {
+            ((DebugMode)inspector).onSerializationStart();
+        }
         try {
             reset();
             // marks if the stream will contain tracking data

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugMode.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugMode.java
@@ -22,6 +22,14 @@ import com.vaadin.kubernetes.starter.sessiontracker.serialization.TransientHandl
  * serialization process.
  */
 public interface DebugMode {
+
+    /**
+     * Hook invoked when serialization process is about to start.
+     */
+    default void onSerializationStart() {
+        // NO-OP
+    }
+
     /**
      * Hook invoked when a not {@link Serializable} object is found during
      * serialization process.
@@ -63,8 +71,14 @@ public interface DebugMode {
      *            object that is going to be serialized.
      */
     default Object onSerialize(Object object, Track track) {
-        // NO-OP
         return object;
+    }
+
+    /**
+     * Hook invoked when deserialization process is about to start.
+     */
+    default void onDeserializationStart() {
+        // NO-OP
     }
 
     /**

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugTransientHandler.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugTransientHandler.java
@@ -33,6 +33,11 @@ class DebugTransientHandler implements TransientHandler, DebugMode {
     }
 
     @Override
+    public void onSerializationStart() {
+        job.reset();
+    }
+
+    @Override
     public void inject(Object object, List<TransientDescriptor> transients) {
         // NO-OP
     }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/Job.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/Job.java
@@ -46,7 +46,7 @@ class Job {
             "class java.lang.invoke.SerializedLambda cannot be cast to class ([^ ]+)( |$)");
 
     private final String sessionId;
-    private final long startTimeNanos;
+    private long startTimeNanos;
     private final Set<Outcome> outcome = new LinkedHashSet<>();
     private final Map<String, List<String>> messages = new LinkedHashMap<>();
     private String storageKey;
@@ -62,9 +62,20 @@ class Job {
         this.startTimeNanos = System.nanoTime();
     }
 
-    public void serializationStarted() {
-        // No-Op
+    void reset() {
+        startTimeNanos = System.nanoTime();
+        storageKey = null;
+        outcome.clear();
+        messages.clear();
+        tracked.clear();
+        deserializingStack.clear();
+        unserializableDetails.clear();
+        serializedLambdaMap.clear();
         outcome.add(Outcome.SERIALIZATION_FAILED);
+    }
+
+    public void serializationStarted() {
+        reset();
     }
 
     void notSerializable(Object obj) {


### PR DESCRIPTION
## Description

When running debug tool, if multiple optimistic serialization attemps are performed the results are duplicated when printed on server logs. With this change debug tool is reset every time a serialization attempt starts.

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
