### PR TITLE
Use service listener to check the license

### DIFF
--- a/kubernetes-kit-starter/pom.xml
+++ b/kubernetes-kit-starter/pom.xml
@@ -10,6 +10,10 @@
 
     <artifactId>kubernetes-kit-starter</artifactId>
 
+    <properties>
+        <cvdl.name>vaadin-kubernetes-kit</cvdl.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>jakarta.servlet</groupId>
@@ -90,6 +94,21 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.jar.version}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <CvdlName>${cvdl.name}</CvdlName>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/kubernetes-kit-starter/pom.xml
+++ b/kubernetes-kit-starter/pom.xml
@@ -83,12 +83,12 @@
     </dependencies>
 
     <build>
-        <testResources>
-            <testResource>
-                <directory>src/test/resources</directory>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
                 <filtering>true</filtering>
-            </testResource>
-        </testResources>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
@@ -17,16 +17,17 @@ import java.util.function.Predicate;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import org.apache.commons.logging.LogFactory;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.ApplicationContext;
@@ -39,6 +40,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.util.StringUtils;
 
+import com.vaadin.flow.spring.SpringBootAutoConfiguration;
 import com.vaadin.kubernetes.starter.sessiontracker.SessionListener;
 import com.vaadin.kubernetes.starter.sessiontracker.SessionSerializer;
 import com.vaadin.kubernetes.starter.sessiontracker.SessionTrackerFilter;
@@ -47,30 +49,21 @@ import com.vaadin.kubernetes.starter.sessiontracker.backend.HazelcastConnector;
 import com.vaadin.kubernetes.starter.sessiontracker.backend.RedisConnector;
 import com.vaadin.kubernetes.starter.sessiontracker.push.PushSendListener;
 import com.vaadin.kubernetes.starter.sessiontracker.push.PushSessionTracker;
-import com.vaadin.kubernetes.starter.sessiontracker.serialization.debug.DebugMode;
-import com.vaadin.kubernetes.starter.sessiontracker.serialization.debug.SerializationDebugRequestHandler;
 import com.vaadin.kubernetes.starter.sessiontracker.serialization.SpringTransientHandler;
 import com.vaadin.kubernetes.starter.sessiontracker.serialization.TransientHandler;
-import com.vaadin.pro.licensechecker.LicenseChecker;
+import com.vaadin.kubernetes.starter.sessiontracker.serialization.debug.DebugMode;
+import com.vaadin.kubernetes.starter.sessiontracker.serialization.debug.SerializationDebugRequestHandler;
 
 /**
  * This configuration bean is provided to auto-configure Vaadin apps to run in a
  * clustered environment.
  */
 @ConditionalOnProperty(name = "auto-configure", prefix = KubernetesKitProperties.PREFIX, matchIfMissing = true)
-@AutoConfiguration(afterName = "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration")
+@AutoConfigureAfter({ SpringBootAutoConfiguration.class,
+        RedisAutoConfiguration.class })
 @EnableConfigurationProperties({ KubernetesKitProperties.class,
         SerializationProperties.class })
 public class KubernetesKitConfiguration {
-
-    static final String PRODUCT_NAME = "vaadin-kubernetes-kit";
-
-    static final String PRODUCT_VERSION = "1.0";
-
-    static {
-        LicenseChecker.checkLicenseFromStaticBlock(PRODUCT_NAME,
-                PRODUCT_VERSION, null);
-    }
 
     @AutoConfiguration
     @ConditionalOnBean(BackendConnector.class)

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/LicenseCheckerServiceInitListener.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/LicenseCheckerServiceInitListener.java
@@ -1,0 +1,54 @@
+/*-
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.kubernetes.starter;
+
+import java.io.IOException;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.pro.licensechecker.BuildType;
+import com.vaadin.pro.licensechecker.LicenseChecker;
+
+import static org.springframework.core.io.support.PropertiesLoaderUtils.loadAllProperties;
+
+/**
+ * Service initialization listener to verify the license.
+ *
+ * @author Vaadin Ltd
+ */
+public class LicenseCheckerServiceInitListener
+        implements VaadinServiceInitListener {
+
+    static final String PROPERTIES_RESOURCE = "kubernetes-kit.properties";
+
+    static final String VERSION_PROPERTY = "kubernetes-kit.version";
+
+    static final String PRODUCT_NAME = "vaadin-kubernetes-kit";
+
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+        final var service = event.getSource();
+
+        // Check the license at runtime if in development mode
+        if (!service.getDeploymentConfiguration().isProductionMode()) {
+            try {
+                final var properties = loadAllProperties(PROPERTIES_RESOURCE);
+                final var version = properties.getProperty(VERSION_PROPERTY);
+
+                // Using a null BuildType to allow trial licensing builds
+                // The variable is defined to avoid method signature ambiguity
+                BuildType buildType = null;
+                LicenseChecker.checkLicense(PRODUCT_NAME, version, buildType);
+            } catch (IOException e) {
+                throw new ExceptionInInitializerError(e);
+            }
+        }
+    }
+}

--- a/kubernetes-kit-starter/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
+++ b/kubernetes-kit-starter/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
@@ -1,1 +1,2 @@
+com.vaadin.kubernetes.starter.LicenseCheckerServiceInitListener
 com.vaadin.kubernetes.starter.ui.ClusterSupport

--- a/kubernetes-kit-starter/src/main/resources/kubernetes-kit.properties
+++ b/kubernetes-kit-starter/src/main/resources/kubernetes-kit.properties
@@ -1,0 +1,1 @@
+kubernetes-kit.version=${project.version}

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/KubernetesKitConfigurationTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/KubernetesKitConfigurationTest.java
@@ -1,48 +1,25 @@
+/*-
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
 package com.vaadin.kubernetes.starter;
-
-import java.io.IOException;
-import java.util.Properties;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import org.junit.jupiter.api.Test;
-import org.springframework.core.io.support.PropertiesLoaderUtils;
 
-import com.vaadin.pro.licensechecker.LicenseChecker;
-
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 class KubernetesKitConfigurationTest {
-
-    static final String PROPERTIES_RESOURCE = "kubernetes-kit.properties";
-
-    @Test
-    public void correctVersionPassedToLicenseChecker() {
-        final var version = getProperties().getProperty("version");
-
-        assertThat(version,
-                startsWith(KubernetesKitConfiguration.PRODUCT_VERSION));
-    }
-
-    @Test
-    public void licenseChecker_licenseIsCheckedFromStaticBlock() {
-        final var mockController = mockStatic(LicenseChecker.class);
-
-        new KubernetesKitConfiguration();
-
-        mockController.verify(() -> LicenseChecker.checkLicenseFromStaticBlock(
-                KubernetesKitConfiguration.PRODUCT_NAME,
-                KubernetesKitConfiguration.PRODUCT_VERSION, null));
-
-        mockController.close();
-    }
 
     @Test
     public void hazelcastInstance_serviceNameSet_kubernetesConfigured() {
@@ -79,14 +56,6 @@ class KubernetesKitConfigurationTest {
             final var mockHazelcastInstance = mock(HazelcastInstance.class);
             when(mockHazelcastInstance.getConfig()).thenReturn(config);
             return mockHazelcastInstance;
-        }
-    }
-
-    private Properties getProperties() {
-        try {
-            return PropertiesLoaderUtils.loadAllProperties(PROPERTIES_RESOURCE);
-        } catch (IOException e) {
-            throw new ExceptionInInitializerError(e);
         }
     }
 }

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/LicenseCheckerServiceInitListenerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/LicenseCheckerServiceInitListenerTest.java
@@ -1,0 +1,92 @@
+/*-
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.kubernetes.starter;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.pro.licensechecker.BuildType;
+import com.vaadin.pro.licensechecker.LicenseChecker;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LicenseCheckerServiceInitListenerTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private VaadinService service;
+
+    private MockedStatic<LicenseChecker> licenseChecker;
+
+    @BeforeEach
+    public void setup() {
+        licenseChecker = mockStatic(LicenseChecker.class);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        licenseChecker.close();
+    }
+
+    @Test
+    public void developmentMode_licenseIsCheckedRuntime() {
+        when(service.getDeploymentConfiguration().isProductionMode())
+                .thenReturn(false);
+
+        final var version = getProperties()
+                .getProperty(LicenseCheckerServiceInitListener.VERSION_PROPERTY);
+
+        // Assert version is in X.Y format
+        assertThat(version, matchesPattern("^\\d\\.\\d.*"));
+
+        final var listener = new LicenseCheckerServiceInitListener();
+        listener.serviceInit(new ServiceInitEvent(service));
+
+        // Verify the license is checked
+        BuildType buildType = null;
+        licenseChecker.verify(() -> LicenseChecker.checkLicense(
+                LicenseCheckerServiceInitListener.PRODUCT_NAME, version, buildType));
+    }
+
+    @Test
+    public void productionMode_licenseIsNotCheckedRuntime() {
+        when(service.getDeploymentConfiguration().isProductionMode())
+                .thenReturn(true);
+
+        final var listener = new LicenseCheckerServiceInitListener();
+        listener.serviceInit(new ServiceInitEvent(service));
+
+        licenseChecker.verifyNoInteractions();
+    }
+
+    private Properties getProperties() {
+        try {
+            return PropertiesLoaderUtils.loadAllProperties(
+                    LicenseCheckerServiceInitListener.PROPERTIES_RESOURCE);
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/kubernetes-kit-starter/src/test/resources/kubernetes-kit.properties
+++ b/kubernetes-kit-starter/src/test/resources/kubernetes-kit.properties
@@ -1,1 +1,0 @@
-version=${project.version}

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <flow.version>23.3-SNAPSHOT</flow.version>
         <spring.boot.version>2.7.4</spring.boot.version>
+        <maven.jar.version>3.3.0</maven.jar.version>
         <maven.source.version>3.2.1</maven.source.version>
         <maven.javadoc.version>3.4.1</maven.javadoc.version>
         <maven.surefire.version>2.22.2</maven.surefire.version>


### PR DESCRIPTION
This moves the license check from a static block to a `VaadinServiceInitListener` so that the check can be done once the `VaadinService` instance is available to know if the app is run in development or production mode.

The check is then performed only if running in development mode.