### PR TITLE
fix: reintroduce Autoconfiguration annotaion

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
@@ -11,7 +11,6 @@ package com.vaadin.kubernetes.starter;
 
 import javax.servlet.FilterRegistration;
 import javax.servlet.ServletContext;
-
 import java.util.function.Predicate;
 
 import com.hazelcast.config.Config;
@@ -58,6 +57,7 @@ import com.vaadin.kubernetes.starter.sessiontracker.serialization.debug.Serializ
  * This configuration bean is provided to auto-configure Vaadin apps to run in a
  * clustered environment.
  */
+@AutoConfiguration
 @ConditionalOnProperty(name = "auto-configure", prefix = KubernetesKitProperties.PREFIX, matchIfMissing = true)
 @AutoConfigureAfter({ SpringBootAutoConfiguration.class,
         RedisAutoConfiguration.class })


### PR DESCRIPTION
In a previous change we replaced `@AutoConfiguration(afterName=...)` with
`@AutoConfigureAfter` annotation, but the latter seems not to activate
the autoconfiguration stuff.
This patch add back the `@AutoConfiguration` annotation, so that kit
configuration are automatically applied at application boot.