### PR TITLE
Add serialization timeout configurable property

### DIFF
--- a/kubernetes-kit-demo/src/main/resources/application.yml
+++ b/kubernetes-kit-demo/src/main/resources/application.yml
@@ -13,11 +13,9 @@ vaadin:
     hazelcast:
       service-name: kubernetes-kit-hazelcast-service
   serialization:
+    timeout: 10000
     transients:
       include-packages: com.vaadin.kubernetes.demo
   devmode:
     sessionSerialization:
       enabled: true
-
-
-

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
@@ -162,10 +162,12 @@ public class KubernetesKitConfiguration {
     @AutoConfiguration
     @Conditional(VaadinReplicatedSessionDevModeConfiguration.OnSessionSerializationDebug.class)
     public static class VaadinReplicatedSessionDevModeConfiguration {
+
         @Bean
         @ConditionalOnMissingBean
-        SerializationDebugRequestHandler.InitListener sessionSerializationDebugToolInstaller() {
-            return new SerializationDebugRequestHandler.InitListener();
+        SerializationDebugRequestHandler.InitListener sessionSerializationDebugToolInstaller(
+                SerializationProperties serializationProperties) {
+            return new SerializationDebugRequestHandler.InitListener(serializationProperties);
         }
 
         @Bean

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/SerializationProperties.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/SerializationProperties.java
@@ -29,7 +29,7 @@ public class SerializationProperties {
 
     public static final String PREFIX = "vaadin.serialization";
 
-    public static final int DEFAULT_SERIALIZATION_TIMEOUT_MS = 5000;
+    public static final int DEFAULT_SERIALIZATION_TIMEOUT_MS = 30000;
 
     private int timeout = DEFAULT_SERIALIZATION_TIMEOUT_MS;
 

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/SerializationProperties.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/SerializationProperties.java
@@ -29,8 +29,35 @@ public class SerializationProperties {
 
     public static final String PREFIX = "vaadin.serialization";
 
+    public static final int DEFAULT_SERIALIZATION_TIMEOUT_MS = 5000;
+
+    private int timeout = DEFAULT_SERIALIZATION_TIMEOUT_MS;
+
     @NestedConfigurationProperty
     private final TransientsProperties transients = new TransientsProperties();
+
+    /**
+     * Gets the timeout in milliseconds to wait for the serialization
+     * to be completed.
+     *
+     * @return the timeout in milliseconds to wait for the serialization
+     * to be completed, defaults to 30000 ms
+     */
+    public int getTimeout() {
+        return timeout;
+    }
+
+    /**
+     * Sets the timeout in milliseconds to wait for the serialization
+     * to be completed.
+     *
+     * @param timeout
+     *            the timeout in milliseconds to wait for the serialization
+     *            to be completed, defaults to 30000 ms
+     */
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
+    }
 
     /**
      * Gets configuration for transient fields handling during serialization.

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
@@ -63,23 +63,28 @@ class DebugBackendConnector implements BackendConnector {
     }
 
     /**
-     * Blocks the thread for up to 10 seconds, waiting for serialization to be
-     * completed.
+     * Blocks the thread for up to the defined timeout in milliseconds,
+     * waiting for serialization to be completed.
      *
+     * @param timeout
+     *            the timeout in milliseconds to wait for the serialization
+     *            to be completed.
      * @param logger
      *            the logger to add potential error information.
      * @return the serialized session holder.
      */
-    SessionInfo waitForCompletion(Logger logger) {
-        int timeout = 10000;
+    SessionInfo waitForCompletion(int timeout, Logger logger) {
         try {
             if (!latch.await(timeout, TimeUnit.MILLISECONDS)) {
+                job.timeout();
                 logger.error(
-                        "Session Serialization did not completed in {} ms.",
+                        "Session serialization timed out because did not complete in {} ms. " +
+                                "Increase the serialization timeout (in milliseconds) by the " +
+                                "'vaadin.serialization.timeout' application or system property.",
                         timeout);
             }
         } catch (Exception e) { // NOSONAR
-            logger.error("Testing of Session Serialization failed", e);
+            logger.error("Testing of session serialization failed", e);
         }
         return sessionInfo;
     }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/Job.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/Job.java
@@ -243,15 +243,17 @@ class Job {
         }
         long duration = TimeUnit.NANOSECONDS
                 .toMillis(System.nanoTime() - this.startTimeNanos);
-        messages.computeIfPresent(Outcome.NOT_SERIALIZABLE_CLASSES.name(),
-                (unused, info) -> info.stream()
-                        .flatMap(className -> Stream.concat(
-                                Stream.of(className),
-                                unserializableDetails
-                                        .getOrDefault(className,
-                                                Collections.emptyList())
-                                        .stream().map(entry -> "\t" + entry)))
-                        .collect(Collectors.toList()));
+        if (!outcome.contains(Outcome.SERIALIZATION_TIMEOUT)) {
+            messages.computeIfPresent(Outcome.NOT_SERIALIZABLE_CLASSES.name(),
+                    (unused, info) -> info.stream()
+                            .flatMap(className -> Stream.concat(
+                                    Stream.of(className),
+                                    unserializableDetails
+                                            .getOrDefault(className,
+                                                    Collections.emptyList())
+                                            .stream().map(entry -> "\t" + entry)))
+                            .collect(Collectors.toList()));
+        }
         return new Result(sessionId, storageKey, outcome, duration, messages);
     }
 

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/Job.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/Job.java
@@ -131,6 +131,11 @@ class Job {
                 Outcome.SERIALIZATION_FAILED.name() + ": " + ex.getMessage());
     }
 
+    void timeout() {
+        outcome.remove(Outcome.SERIALIZATION_FAILED);
+        outcome.add(Outcome.SERIALIZATION_TIMEOUT);
+    }
+
     void deserialized() {
         outcome.remove(Outcome.DESERIALIZATION_FAILED);
     }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/Outcome.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/Outcome.java
@@ -26,6 +26,10 @@ public enum Outcome {
      */
     SERIALIZATION_FAILED,
     /**
+     * Serialization did not complete in time
+     */
+    SERIALIZATION_TIMEOUT,
+    /**
      * Process failed during deserialization phase
      */
     DESERIALIZATION_FAILED,

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/Result.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/Result.java
@@ -12,6 +12,7 @@ package com.vaadin.kubernetes.starter.sessiontracker.serialization.debug;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +37,7 @@ public class Result implements Serializable {
         this.storageKey = storageKey;
         this.outcomes = new LinkedHashSet<>(outcomes);
         this.duration = duration;
-        this.messages = messages;
+        this.messages = new LinkedHashMap<>(messages);
     }
 
     /**

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/VaadinReplicatedSessionDevModeConfigurationTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/VaadinReplicatedSessionDevModeConfigurationTest.java
@@ -19,6 +19,7 @@ class VaadinReplicatedSessionDevModeConfigurationTest {
                         "sun.io.serialization.extendedDebugInfo=true")
                 .withPropertyValues("vaadin.productionMode=true",
                         "vaadin.devmode.sessionSerialization.enabled=true")
+                .withBean(SerializationProperties.class)
                 .withConfiguration(AutoConfigurations.of(
                         KubernetesKitConfiguration.VaadinReplicatedSessionDevModeConfiguration.class))
                 .run(appCtx -> Assertions.assertThat(appCtx.getBeanNamesForType(
@@ -33,6 +34,7 @@ class VaadinReplicatedSessionDevModeConfigurationTest {
                         "sun.io.serialization.extendedDebugInfo=true")
                 .withPropertyValues("vaadin.productionMode=true",
                         "vaadin.devmode.sessionSerialization.enabled=false")
+                .withBean(SerializationProperties.class)
                 .withConfiguration(AutoConfigurations.of(
                         KubernetesKitConfiguration.VaadinReplicatedSessionDevModeConfiguration.class))
                 .run(appCtx -> Assertions.assertThat(appCtx.getBeanNamesForType(
@@ -46,6 +48,7 @@ class VaadinReplicatedSessionDevModeConfigurationTest {
                 .withSystemProperties(
                         "sun.io.serialization.extendedDebugInfo=true")
                 .withPropertyValues("vaadin.productionMode=true")
+                .withBean(SerializationProperties.class)
                 .withConfiguration(AutoConfigurations.of(
                         KubernetesKitConfiguration.VaadinReplicatedSessionDevModeConfiguration.class))
                 .run(appCtx -> Assertions.assertThat(appCtx.getBeanNamesForType(
@@ -60,6 +63,7 @@ class VaadinReplicatedSessionDevModeConfigurationTest {
                         "sun.io.serialization.extendedDebugInfo=true")
                 .withPropertyValues(
                         "vaadin.devmode.sessionSerialization.enabled=true")
+                .withBean(SerializationProperties.class)
                 .withConfiguration(AutoConfigurations.of(
                         KubernetesKitConfiguration.VaadinReplicatedSessionDevModeConfiguration.class))
                 .run(appCtx -> Assertions.assertThat(appCtx.getBeanNamesForType(
@@ -74,6 +78,7 @@ class VaadinReplicatedSessionDevModeConfigurationTest {
                         "sun.io.serialization.extendedDebugInfo=true")
                 .withPropertyValues(
                         "vaadin.devmode.sessionSerialization.enabled=false")
+                .withBean(SerializationProperties.class)
                 .withConfiguration(AutoConfigurations.of(
                         KubernetesKitConfiguration.VaadinReplicatedSessionDevModeConfiguration.class))
                 .run(appCtx -> Assertions.assertThat(appCtx.getBeanNamesForType(
@@ -86,6 +91,7 @@ class VaadinReplicatedSessionDevModeConfigurationTest {
         new ApplicationContextRunner()
                 .withSystemProperties(
                         "sun.io.serialization.extendedDebugInfo=true")
+                .withBean(SerializationProperties.class)
                 .withConfiguration(AutoConfigurations.of(
                         KubernetesKitConfiguration.VaadinReplicatedSessionDevModeConfiguration.class))
                 .run(appCtx -> Assertions.assertThat(appCtx.getBeanNamesForType(
@@ -100,6 +106,7 @@ class VaadinReplicatedSessionDevModeConfigurationTest {
                         "sun.io.serialization.extendedDebugInfo=true")
                 .withPropertyValues("vaadin.productionMode=false",
                         "vaadin.devmode.sessionSerialization.enabled=true")
+                .withBean(SerializationProperties.class)
                 .withConfiguration(AutoConfigurations.of(
                         KubernetesKitConfiguration.VaadinReplicatedSessionDevModeConfiguration.class))
                 .run(appCtx -> Assertions.assertThat(appCtx.getBeanNamesForType(
@@ -114,6 +121,7 @@ class VaadinReplicatedSessionDevModeConfigurationTest {
                         "sun.io.serialization.extendedDebugInfo=true")
                 .withPropertyValues("vaadin.productionMode=false",
                         "vaadin.devmode.sessionSerialization.enabled=false")
+                .withBean(SerializationProperties.class)
                 .withConfiguration(AutoConfigurations.of(
                         KubernetesKitConfiguration.VaadinReplicatedSessionDevModeConfiguration.class))
                 .run(appCtx -> Assertions.assertThat(appCtx.getBeanNamesForType(
@@ -127,6 +135,7 @@ class VaadinReplicatedSessionDevModeConfigurationTest {
                 .withSystemProperties(
                         "sun.io.serialization.extendedDebugInfo=true")
                 .withPropertyValues("vaadin.productionMode=false")
+                .withBean(SerializationProperties.class)
                 .withConfiguration(AutoConfigurations.of(
                         KubernetesKitConfiguration.VaadinReplicatedSessionDevModeConfiguration.class))
                 .run(appCtx -> Assertions.assertThat(appCtx.getBeanNamesForType(
@@ -141,6 +150,7 @@ class VaadinReplicatedSessionDevModeConfigurationTest {
                         "sun.io.serialization.extendedDebugInfo=true")
                 .withPropertyValues(
                         "vaadin.devmode.sessionSerialization.enabled=true")
+                .withBean(SerializationProperties.class)
                 .withConfiguration(AutoConfigurations.of(
                         KubernetesKitConfiguration.VaadinReplicatedSessionDevModeConfiguration.class))
                 .run(appCtx -> Assertions.assertThat(appCtx.getBeanNamesForType(
@@ -155,6 +165,7 @@ class VaadinReplicatedSessionDevModeConfigurationTest {
                         "sun.io.serialization.extendedDebugInfo=false")
                 .withPropertyValues(
                         "vaadin.devmode.sessionSerialization.enabled=true")
+                .withBean(SerializationProperties.class)
                 .withConfiguration(AutoConfigurations.of(
                         KubernetesKitConfiguration.VaadinReplicatedSessionDevModeConfiguration.class))
                 .run(appCtx -> Assertions.assertThat(appCtx.getBeanNamesForType(
@@ -170,6 +181,7 @@ class VaadinReplicatedSessionDevModeConfigurationTest {
                         "sun.io.serialization.extendedDebugInfo=true")
                 .withPropertyValues(
                         "vaadin.devmode.sessionSerialization.enabled=true")
+                .withBean(SerializationProperties.class)
                 .withConfiguration(AutoConfigurations.of(
                         KubernetesKitConfiguration.VaadinReplicatedSessionDevModeConfiguration.class))
                 .run(appCtx -> Assertions.assertThat(appCtx.getBeanNamesForType(

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandlerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandlerTest.java
@@ -1,7 +1,5 @@
 package com.vaadin.kubernetes.starter.sessiontracker.serialization.debug;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -10,13 +8,14 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.data.Index;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpSession;
 
 import com.vaadin.flow.component.PushConfiguration;
@@ -34,6 +33,7 @@ import com.vaadin.flow.server.WrappedHttpSession;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.communication.PushMode;
+import com.vaadin.kubernetes.starter.SerializationProperties;
 import com.vaadin.kubernetes.starter.sessiontracker.serialization.debug.SerializationDebugRequestHandler.Runner;
 import com.vaadin.kubernetes.starter.test.EnableOnJavaIOReflection;
 import com.vaadin.kubernetes.starter.ui.SessionDebugNotifier;
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @EnableOnJavaIOReflection
-@EnabledIfSystemProperty(named = "sun.io.serialization.extendedDebugInfo", matches = "true", //
+@EnabledIfSystemProperty(named = "sun.io.serialization.extendedDebugInfo", matches = "true",
         disabledReason = "Tests need system property sun.io.serialization.extendedDebugInfo to be enabled")
 class SerializationDebugRequestHandlerTest {
 
@@ -66,7 +66,9 @@ class SerializationDebugRequestHandlerTest {
 
     @BeforeEach
     void setUp() {
-        handler = new SerializationDebugRequestHandler();
+        SerializationProperties serializationProperties = new SerializationProperties();
+        serializationProperties.setTimeout(30000);
+        handler = new SerializationDebugRequestHandler(serializationProperties);
         httpSession = new MockHttpSession();
         VaadinService vaadinService = mock(VaadinService.class);
         VaadinContext vaadinContext = mock(VaadinContext.class);
@@ -81,11 +83,9 @@ class SerializationDebugRequestHandlerTest {
                 resultHolder.set(result);
             }
         });
-        doAnswer(i -> {
-            SerializableConsumer<Result> consumer = resultHolder::set;
-            return consumer;
-        }).when(ui).accessLater(any(SerializableConsumer.class),
-                any(SerializableRunnable.class));
+        doAnswer(i -> (SerializableConsumer<Result>) resultHolder::set)
+                .when(ui).accessLater(any(SerializableConsumer.class),
+                        any(SerializableRunnable.class));
         when(ui.getPushConfiguration()).thenReturn(pushConfiguration);
         when(vaadinService.findUI(any())).thenReturn(ui);
 
@@ -120,7 +120,6 @@ class SerializationDebugRequestHandlerTest {
         when(httpRequest.isRequestedSessionIdValid()).thenReturn(true);
         resultHolder = new AtomicReference<>();
         response = mock(VaadinResponse.class);
-
     }
 
     @Test
@@ -138,7 +137,7 @@ class SerializationDebugRequestHandlerTest {
     }
 
     @Test
-    void handleRequest_notUIDLrequest_skip() {
+    void handleRequest_notUIDLRequest_skip() {
         reset(request);
         when(request.getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
                 .thenReturn(HandlerHelper.RequestType.INIT.getIdentifier());
@@ -150,7 +149,7 @@ class SerializationDebugRequestHandlerTest {
 
     @Test
     void handleRequest_productionMode_skip() {
-        Mockito.reset(appConfig);
+        reset(appConfig);
         when(appConfig.isProductionMode()).thenReturn(true);
         when(appConfig.isDevModeSessionSerializationEnabled()).thenReturn(true);
 
@@ -161,7 +160,7 @@ class SerializationDebugRequestHandlerTest {
 
     @Test
     void handleRequest_serializationDebugDisabled_skip() {
-        Mockito.reset(appConfig);
+        reset(appConfig);
         when(appConfig.isProductionMode()).thenReturn(false);
         when(appConfig.isDevModeSessionSerializationEnabled())
                 .thenReturn(false);

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandlerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandlerTest.java
@@ -297,6 +297,21 @@ class SerializationDebugRequestHandlerTest {
     }
 
     @Test
+    void handleRequest_serializationTimeout_timeoutReported() {
+        SerializationProperties properties = new SerializationProperties();
+        properties.setTimeout(1);
+        handler = new SerializationDebugRequestHandler(properties);
+
+        httpSession.setAttribute("OBJ1", new DeepNested());
+
+        runDebugTool();
+        Result result = resultHolder.get();
+        assertThat(result.getSessionId()).isEqualTo(httpSession.getId());
+        assertThat(result.getOutcomes()).containsExactlyInAnyOrder(
+                Outcome.NOT_SERIALIZABLE_CLASSES, Outcome.SERIALIZATION_TIMEOUT);
+    }
+
+    @Test
     @Disabled("Find a way to simulate SerializedLambda ClassCastException")
     void handleRequest_lambdaSelfReferenceClassCast_errorCaught() {
     }


### PR DESCRIPTION
- Makes serialization timeout configurable to wait for the serialization to be completed (default timeout has been increased to 30s)
  - If using SpringBoot then a `timeout` property in `SerializationProperties` is available to set the timeout
  - If not using SpringBoot then a `vaadin.serialization.timeout` system property is available to set the timeout
- Updates log messages to make it more clear when a serialization timeout happens and when a serialization job is finished
- Adds check for serialization timeout when updating the result messages in `Job::complete` to avoid `ConcurrentModificationException` because in case of timeout the serialization could still run and updating the messages too

Closes #94 and #97 