### PR TITLE
fix: fix session serialization for PUSH with websocket

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/push/NotifyingPushConnection.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/push/NotifyingPushConnection.java
@@ -9,6 +9,8 @@
  */
 package com.vaadin.kubernetes.starter.sessiontracker.push;
 
+import java.util.function.Consumer;
+
 import org.atmosphere.cpr.AtmosphereResource;
 
 import com.vaadin.flow.component.UI;
@@ -34,12 +36,22 @@ public class NotifyingPushConnection extends AtmospherePushConnection {
     }
 
     @Override
+    public void connect(AtmosphereResource resource) {
+        super.connect(resource);
+        notifyPushListeners(listener -> listener.onConnect(resource));
+    }
+
+    @Override
     protected void sendMessage(String message) {
         super.sendMessage(message);
         AtmosphereResource resource = getResource();
+        notifyPushListeners(listener -> listener.onMessageSent(resource));
+    }
+
+    private void notifyPushListeners(Consumer<PushSendListener> action) {
         getUI().getSession().getService().getContext()
                 .getAttribute(Lookup.class).lookupAll(PushSendListener.class)
-                .forEach(listener -> listener.onMessageSent(resource));
+                .forEach(action);
     }
 
     /**

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/push/PushSendListener.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/push/PushSendListener.java
@@ -12,10 +12,27 @@ package com.vaadin.kubernetes.starter.sessiontracker.push;
 import org.atmosphere.cpr.AtmosphereResource;
 
 /**
- * Associates AtmosphereResource with a PushConnection identifier in order to be
- * able to reattach them later on.
+ * Component notified when a UIDL message is sent to the client via PUSH
+ * mechanism.
+ * <p>
+ * </p>
+ * The component is also notified when the PUSH connection is established in
+ * order to perform initialization tasks for the connected resource.
+ * <p>
+ * </p>
+ * Implementation must be thread safe, since method invocation may originate in
+ * different threads.
  */
 public interface PushSendListener {
+
+    /**
+     * Invoked when a new PUSH connection is established.
+     *
+     * @param resource
+     *            the {@link AtmosphereResource} behind the PUSH connection.
+     */
+    default void onConnect(AtmosphereResource resource) {
+    }
 
     /**
      * Invoked whenever a UIDL message has been sent to the client.

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/push/NotifyingPushConnectionTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/push/NotifyingPushConnectionTest.java
@@ -38,6 +38,7 @@ public class NotifyingPushConnectionTest {
         connection.connect(resource);
         connection.sendMessage("foo");
 
+        verify(listener).onConnect(eq(resource));
         verify(listener).onMessageSent(eq(resource));
     }
 

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/push/PushSessionTrackerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/push/PushSessionTrackerTest.java
@@ -3,10 +3,15 @@ package com.vaadin.kubernetes.starter.sessiontracker.push;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+
 import java.util.UUID;
 
+import org.atmosphere.cpr.AtmosphereFramework;
 import org.atmosphere.cpr.AtmosphereRequest;
 import org.atmosphere.cpr.AtmosphereResource;
+import org.atmosphere.cpr.AtmosphereResourceSession;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.kubernetes.starter.sessiontracker.CurrentKey;
@@ -22,35 +27,99 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class PushSessionTrackerTest {
+
+    private HttpSession httpSession;
+    private HttpServletRequest servletRequest;
+    private SessionSerializer sessionSerializer;
+    private PushSessionTracker sessionTracker;
+
+    @BeforeEach
+    void setup() {
+        httpSession = mock(HttpSession.class);
+        servletRequest = mock(HttpServletRequest.class);
+        sessionSerializer = mock(SessionSerializer.class);
+        sessionTracker = new PushSessionTracker(sessionSerializer);
+        sessionTracker.setActiveSessionChecker(id -> true);
+    }
+
+    AtmosphereResource createResource(String clusterKey) {
+        AtmosphereResource resource = mock(AtmosphereResource.class);
+        when(resource.uuid()).thenReturn(UUID.randomUUID().toString());
+
+        AtmosphereFramework atmosphere = new AtmosphereFramework();
+        when(resource.getAtmosphereConfig())
+                .thenReturn(atmosphere.getAtmosphereConfig());
+
+        if (clusterKey != null) {
+            atmosphere.getAtmosphereConfig().sessionFactory()
+                    .getSession(resource)
+                    .setAttribute(CurrentKey.COOKIE_NAME, clusterKey);
+        }
+
+        when(resource.session(anyBoolean())).thenReturn(httpSession);
+        AtmosphereRequest request = mock(AtmosphereRequest.class);
+        when(resource.getRequest()).thenReturn(request);
+        when(request.wrappedRequest()).thenReturn(servletRequest);
+        return resource;
+    }
+
+    @Test
+    void onConnect_clusterKeyFromCookie_storeClusterKeyOnResourceSession() {
+        AtmosphereResource resource = createResource(null);
+        String clusterKey = UUID.randomUUID().toString();
+        when(servletRequest.getCookies()).thenReturn(new Cookie[] {
+                new Cookie(CurrentKey.COOKIE_NAME, clusterKey) });
+
+        sessionTracker.onConnect(resource);
+
+        AtmosphereResourceSession resourceSession = resource
+                .getAtmosphereConfig().sessionFactory()
+                .getSession(resource, false);
+        Assertions.assertEquals(clusterKey,
+                resourceSession.getAttribute(CurrentKey.COOKIE_NAME));
+    }
+
+    @Test
+    void onConnect_clusterKeyFromHTTPSession_storeClusterKeyOnResourceSession() {
+        AtmosphereResource resource = createResource(null);
+        String clusterKey = UUID.randomUUID().toString();
+        when(httpSession.getAttribute(CurrentKey.COOKIE_NAME))
+                .thenReturn(clusterKey);
+
+        sessionTracker.onConnect(resource);
+
+        AtmosphereResourceSession resourceSession = resource
+                .getAtmosphereConfig().sessionFactory()
+                .getSession(resource, false);
+        Assertions.assertEquals(clusterKey,
+                resourceSession.getAttribute(CurrentKey.COOKIE_NAME));
+    }
+
     @Test
     void onMessageSent_nullSession_sessionIsNotSerialized() {
-        SessionSerializer sessionSerializer = mock(SessionSerializer.class);
-
         AtmosphereResource resource = mock(AtmosphereResource.class);
         when(resource.session(anyBoolean())).thenReturn(null);
 
-        PushSessionTracker sessionTracker = new PushSessionTracker(
-                sessionSerializer);
         sessionTracker.onMessageSent(resource);
 
         verify(sessionSerializer, never()).serialize(any(HttpSession.class));
     }
 
     @Test
-    void onMessageSent_invalidatedSession_sessionIsNotSerialized() {
-        SessionSerializer sessionSerializer = mock(SessionSerializer.class);
+    void onMessageSent_missingClusterKey_sessionIsNotSerialized() {
+        AtmosphereResource resource = createResource(null);
 
-        AtmosphereResource resource = mock(AtmosphereResource.class);
-        HttpSession session = mock(HttpSession.class);
-        when(resource.session(anyBoolean())).thenReturn(session);
-        AtmosphereRequest request = mock(AtmosphereRequest.class);
-        when(resource.getRequest()).thenReturn(request);
-        HttpServletRequest servletRequest = mock(HttpServletRequest.class);
-        when(request.wrappedRequest()).thenReturn(servletRequest);
-        when(servletRequest.isRequestedSessionIdValid()).thenReturn(false);
+        sessionTracker.onMessageSent(resource);
 
-        PushSessionTracker sessionTracker = new PushSessionTracker(
-                sessionSerializer);
+        verify(sessionSerializer, never()).serialize(any(HttpSession.class));
+    }
+
+    @Test
+    void onMessageSent_inactiveSession_sessionIsNotSerialized() {
+        AtmosphereResource resource = createResource(
+                UUID.randomUUID().toString());
+
+        sessionTracker.setActiveSessionChecker(id -> false);
         sessionTracker.onMessageSent(resource);
 
         verify(sessionSerializer, never()).serialize(any(HttpSession.class));
@@ -58,25 +127,12 @@ class PushSessionTrackerTest {
 
     @Test
     void onMessageSent_sessionIsSerialized() {
-        SessionSerializer sessionSerializer = mock(SessionSerializer.class);
-
-        AtmosphereResource resource = mock(AtmosphereResource.class);
-        HttpSession session = mock(HttpSession.class);
-        when(resource.session(anyBoolean())).thenReturn(session);
-        AtmosphereRequest request = mock(AtmosphereRequest.class);
-        when(resource.getRequest()).thenReturn(request);
-        HttpServletRequest servletRequest = mock(HttpServletRequest.class);
-        when(request.wrappedRequest()).thenReturn(servletRequest);
-        when(servletRequest.isRequestedSessionIdValid()).thenReturn(true);
         String clusterKey = UUID.randomUUID().toString();
-        when(servletRequest.getCookies()).thenReturn(new Cookie[] {
-                new Cookie(CurrentKey.COOKIE_NAME, clusterKey) });
+        AtmosphereResource resource = createResource(clusterKey);
 
-        PushSessionTracker sessionTracker = new PushSessionTracker(
-                sessionSerializer);
         sessionTracker.onMessageSent(resource);
 
-        verify(sessionSerializer).serialize(eq(session));
+        verify(sessionSerializer).serialize(eq(httpSession));
         assertNull(CurrentKey.get());
     }
 }


### PR DESCRIPTION
## Description

When PUSH transport is websocket, the request associated to atmosphere is a stub implementation that always returns false for 'isRequestedSessionIdValid()' preventing PushSessionTracker to serialize the session.
In addition, accessing the request from a background thread may throw IllegalStateException if the servlet container is recycling request objects (e.g. Tomcat facade). With this change, the session validity is checked against the SessionListener that is already observing session lifecycle events.

Fixes #119

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
