### PR TITLE
fix: make backend operation asynchronous

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
@@ -33,7 +33,7 @@ class DebugBackendConnector implements BackendConnector {
 
     private SessionInfo sessionInfo;
 
-    private CountDownLatch latch;
+    private CountDownLatch latch = new CountDownLatch(2);
 
     @Override
     public void sendSession(SessionInfo sessionInfo) {
@@ -47,7 +47,7 @@ class DebugBackendConnector implements BackendConnector {
 
     @Override
     public void markSerializationStarted(String clusterKey) {
-        latch = new CountDownLatch(1);
+        latch.countDown();
         job.serializationStarted();
     }
 


### PR DESCRIPTION
## Description

If the backed connector fails or hangs during serialization enqueue phase, the UI may freeze or behave incorrectly.
This change makes all backed operations run asynchronously so that the user is not affected by errors caused by the session storage.

Fixes #114

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
