### PR TITLE
fix: avoid injectable transient inspection on Track objects

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/TransientInjectableObjectOutputStream.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/TransientInjectableObjectOutputStream.java
@@ -233,7 +233,7 @@ public class TransientInjectableObjectOutputStream extends ObjectOutputStream {
     @Override
     protected Object replaceObject(Object obj) {
         obj = trackObject(obj);
-        if (obj != null) {
+        if (obj != null && !(obj instanceof Track)) {
             Class<?> type = obj.getClass();
             if (injectableFilter.test(type) && !inspected.containsKey(obj)) {
                 Object original = obj;
@@ -290,10 +290,10 @@ public class TransientInjectableObjectOutputStream extends ObjectOutputStream {
     }
 
     private Object trackObject(Object obj) {
-        if (getLogger().isTraceEnabled()) {
-            getLogger().trace("Serializing object {}", obj.getClass());
-        }
         if (trackingMode && trackingEnabled && !tracking.containsKey(obj)) {
+            if (getLogger().isTraceEnabled()) {
+                getLogger().trace("Serializing object {}", obj.getClass());
+            }
             Object original = obj;
             try {
                 Track track = createTrackObject(++trackingCounter, obj);

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/SerializationDeserializationTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/SerializationDeserializationTest.java
@@ -1,6 +1,7 @@
 package com.vaadin.kubernetes.starter.sessiontracker.serialization;
 
 import jakarta.activation.MimeType;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
@@ -13,11 +14,16 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.vaadin.kubernetes.starter.sessiontracker.serialization.debug.DebugMode;
+import com.vaadin.kubernetes.starter.sessiontracker.serialization.debug.Track;
+import com.vaadin.kubernetes.starter.test.EnableOnJavaIOReflection;
 
 @ContextConfiguration(classes = TestConfig.class)
 @ExtendWith(SpringExtension.class)
@@ -98,6 +104,26 @@ class SerializationDeserializationTest {
 
         Mockito.verify(mockHandler).inspect(obj);
         Mockito.verifyNoMoreInteractions(mockHandler);
+    }
+
+    @Test
+    @EnableOnJavaIOReflection
+    void serialization_transientInspection_trackObjectsIgnored(
+            @Autowired TestConfig.CtorInjectionTarget obj) throws Exception {
+        List<Object> target = new ArrayList<>();
+        target.add(new HashMap<>());
+        target.add(obj);
+        target.add(new MimeType());
+
+        TransientHandler mockHandler = Mockito.mock(TransientHandler.class,
+                Mockito.withSettings().extraInterfaces(DebugMode.class));
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        TransientInjectableObjectOutputStream.newInstance(os, mockHandler)
+                .writeWithTransients(target);
+
+        Mockito.verify(mockHandler, Mockito.never())
+                .inspect(ArgumentMatchers.argThat(o -> o instanceof Track));
     }
 
     @Test


### PR DESCRIPTION
Track object created during serialization do not have injectable transient fields, so the inspection can be safely skipped.

Refs #125