### PR TITLE
fix: shutdown SessionSerializer executor service

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
@@ -504,6 +504,11 @@ public class SessionSerializer
         // the server has not shut down before this and made the session
         // unavailable
         waitForSerialization();
+        destroy();
+    }
+
+    public void destroy() {
+        this.executorService.shutdown();
     }
 
     private static class SerializationThreadFactory implements ThreadFactory {

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
@@ -89,4 +89,8 @@ class DebugBackendConnector implements BackendConnector {
         return sessionInfo;
     }
 
+    void destroy() {
+        sessionInfo = null;
+        job.reset();
+    }
 }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
@@ -16,6 +16,7 @@ import jakarta.servlet.http.HttpFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -219,6 +220,7 @@ public class SerializationDebugRequestHandler implements RequestHandler {
             }
         } finally {
             Result result = job.complete();
+            connector.destroy();
             StringBuilder message = new StringBuilder(
                     "Session serialization attempt finished in ")
                     .append(result.getDuration()).append(" ms with outcomes: ")
@@ -250,6 +252,8 @@ public class SerializationDebugRequestHandler implements RequestHandler {
             }
             LOGGER.info(message.toString()); // NOSONAR
             onComplete.accept(result);
+            // shutdown temporary serializer
+            serializer.destroy();
         }
     }
 


### PR DESCRIPTION
When running the debug tool, a new SessionSerializer instance is created for every request, but once the serialization/deserialization process finishes the internal executor service is not stopped.
This change stops the executor service in the ContextClosedEvent, and it forces the listener to be called also by the debug tool.
