### PR TITLE
refactor: debug tool improvements

### DIFF
--- a/kubernetes-kit-demo/src/main/java/com/vaadin/kubernetes/demo/generator/DataGenerator.java
+++ b/kubernetes-kit-demo/src/main/java/com/vaadin/kubernetes/demo/generator/DataGenerator.java
@@ -69,7 +69,7 @@ public class DataGenerator {
                         contact.setCompany(companies.get(companyIndex));
                         int contactIndex = r.nextInt(statuses.size());
                         contact.setStatus(statuses.get(contactIndex));
-                    }).limit(50).toList();
+                    }).limit(1500).toList();
 
             contactRepository.saveAll(contacts);
 

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/Job.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/Job.java
@@ -46,7 +46,7 @@ class Job {
     private static final Pattern SERIALIZEDLAMBDA_CANNOT_CAST = Pattern.compile(
             "class java.lang.invoke.SerializedLambda cannot be cast to class ([^ ]+)( |$)");
 
-    private CountDownLatch serializationLatch = new CountDownLatch(1);
+    private CountDownLatch serializationLatch = new CountDownLatch(2);
     private final String sessionId;
     private long startTimeNanos;
     private final Set<Outcome> outcome = new LinkedHashSet<>();
@@ -115,7 +115,7 @@ class Job {
     }
 
     public void serializationStarted() {
-        serializationLatch = new CountDownLatch(1);
+        serializationLatch.countDown();
         reset();
     }
 

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/Outcome.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/Outcome.java
@@ -18,6 +18,10 @@ public enum Outcome {
      */
     NOT_STARTED,
     /**
+     * Process has been canceled. May happen only on server shutdown.
+     */
+    CANCELED,
+    /**
      * Not serializable classes found during serialization phase
      */
     NOT_SERIALIZABLE_CLASSES,

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/FailingToStringReplacerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/FailingToStringReplacerTest.java
@@ -23,7 +23,8 @@ class FailingToStringReplacerTest {
     void toStringReplacer_objectSerialized()
             throws IOException, ClassNotFoundException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        TransientHandler handler = new DebugTransientHandler(new Job("TEST"));
+        TransientHandler handler = new DebugTransientHandler(
+                new Job("SID", "KEY"));
 
         ThrowingToStringWithFields obj = new ThrowingToStringWithFields();
 


### PR DESCRIPTION
Refactors SerializationDebugRequestHandler and DebugBackendConnector to improve performance.
Using a single SessionSerializer instance prevents creation of multiple (never stopped) executor services, serialization timeouts due to locks of VaadinSession because of concurrent requests, and excessive memory usage to store serialized data in memory for concurrent requests. Requests occurring during a serialization process are now silently ignored, (how it happens in production) since SessionSerializer has its own mechanism to guarantee that all changes are serialized.

Part of #128
Fixes #125