### PR TITLE
backport: Fix issue when trying to determine if a bean has been defined for transient fields.

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/SpringTransientHandler.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/SpringTransientHandler.java
@@ -104,7 +104,8 @@ public class SpringTransientHandler implements TransientHandler {
 
     private boolean matchesPrototype(String beanName, Object beanDefinition,
             Class<?> fieldValueType) {
-        return appCtx.isPrototype(beanName)
+        return appCtx.containsBeanDefinition(beanName)
+                && appCtx.isPrototype(beanName)
                 && beanDefinition.getClass() == fieldValueType;
     }
 


### PR DESCRIPTION
Backport #90 