### PR TITLE
fix: set clusterKey cookie at first request

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerCookie.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerCookie.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -45,11 +46,14 @@ public final class SessionTrackerCookie {
         Optional<Cookie> clusterKeyCookie = getCookie(request);
         if (clusterKeyCookie.isEmpty()) {
             String clusterKey = UUID.randomUUID().toString();
-            session.setAttribute(CurrentKey.COOKIE_NAME, clusterKey);
+            if (session != null) {
+                session.setAttribute(CurrentKey.COOKIE_NAME, clusterKey);
+            }
             Cookie cookie = new Cookie(CurrentKey.COOKIE_NAME, clusterKey);
             cookieConsumer.accept(cookie);
             response.addCookie(cookie);
-        } else if (session.getAttribute(CurrentKey.COOKIE_NAME) == null) {
+        } else if (session != null
+                && session.getAttribute(CurrentKey.COOKIE_NAME) == null) {
             String clusterKey = clusterKeyCookie.get().getValue();
             session.setAttribute(CurrentKey.COOKIE_NAME, clusterKey);
         }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerFilter.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerFilter.java
@@ -16,6 +16,7 @@ import jakarta.servlet.http.HttpFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+
 import java.io.IOException;
 import java.util.function.Consumer;
 
@@ -72,10 +73,8 @@ public class SessionTrackerFilter extends HttpFilter {
         try {
             HttpSession session = request.getSession(false);
 
-            if (session != null) {
-                SessionTrackerCookie.setIfNeeded(session, request, response,
-                        cookieConsumer(request));
-            }
+            SessionTrackerCookie.setIfNeeded(session, request, response,
+                    cookieConsumer(request));
             super.doFilter(request, response, chain);
 
             if (session != null && request.isRequestedSessionIdValid()

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerCookieTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerCookieTest.java
@@ -144,4 +144,23 @@ public class SessionTrackerCookieTest {
         assertTrue(value.isPresent());
         assertEquals(clusterKey, value.get());
     }
+
+
+    @Test
+    void setIfNeeded_nullCookiesAndSession_cookieIsConfigured() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getCookies()).thenReturn(null);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        @SuppressWarnings("unchecked")
+        Consumer<Cookie> cookieConsumer = (Consumer<Cookie>) mock(
+                Consumer.class);
+
+        SessionTrackerCookie.setIfNeeded(null, request, response,
+                cookieConsumer);
+
+        verify(cookieConsumer).accept(any());
+        verify(response).addCookie(any());
+    }
+
+
 }


### PR DESCRIPTION
## Description

Currently clusterKey cookie is set only when an HTTP session exists. In addition to the cookie, the key is also set as a session attribute so that SessionSerializer can fetch it later.
However, if two or more concurrent requests are sent from the client, all of them create a new cookie, but the session attribute gets the value of the first one. This causes the distributed session to be written with a wrong key and when there a server switch the session cannot be restored. This change sets the clusterKey cookie even if there is not yet an HTTP session, so the key is only defined during first request and remains stable with subsequent calls; once the HTTP session is create, the key is stored as an attribute.

Potentially fixes #111

See https://github.com/vaadin/kubernetes-kit/issues/111\#issuecomment-2074909790

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
