### PR TITLE
fix: prevent usage of VaadinRequest in access

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/ui/ClusterSupport.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/ui/ClusterSupport.java
@@ -52,13 +52,6 @@ public class ClusterSupport implements VaadinServiceInitListener {
     private String appVersion;
 
     /**
-     * Get the current instance of the ClusterSupport.
-     */
-    public static ClusterSupport getCurrent() {
-        return CurrentInstance.get(ClusterSupport.class);
-    }
-
-    /**
      * Register the global version switch listener. If set to <code>null</code>
      * the current session and the sticky cluster cookie are removed without any
      * version switch condition check.
@@ -82,24 +75,20 @@ public class ClusterSupport implements VaadinServiceInitListener {
                 "ClusterSupport service initialized. Registering RequestHandler with Application Version: "
                         + appVersion);
 
-        // Set the thread local instance
-        CurrentInstance.set(ClusterSupport.class, this);
-
         // Register a generic request handler for all the requests
         serviceInitEvent.addRequestHandler(this::handleRequest);
     }
 
     private boolean handleRequest(VaadinSession vaadinSession,
             VaadinRequest vaadinRequest, VaadinResponse vaadinResponse) {
+        String versionHeader = vaadinRequest
+                .getHeader(UPDATE_VERSION_HEADER);
 
         vaadinSession.access(() -> {
-            // Always check for the update version header
-            String versionHeader = vaadinRequest
-                    .getHeader(UPDATE_VERSION_HEADER);
 
+            // Always check for the update version header
+            WrappedSession session = vaadinSession.getSession();
             vaadinSession.getUIs().forEach(ui -> {
-                WrappedSession session = VaadinRequest.getCurrent()
-                        .getWrappedSession();
                 Optional<Component> versionNotifier = ui.getChildren()
                         .filter(child -> (child instanceof VersionNotifier))
                         .findFirst();

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/ui/ClusterSupportTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/ui/ClusterSupportTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.stream.Stream;
 
+import org.junit.Ignore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -85,16 +87,6 @@ public class ClusterSupportTest {
     }
 
     @Test
-    void serviceInit_clusterSupportIsSetInCurrentInstance() {
-        ServiceInitEvent serviceInitEvent = mock(ServiceInitEvent.class);
-
-        clusterSupport.serviceInit(serviceInitEvent);
-
-        currentInstanceMockedStatic
-                .verify(() -> CurrentInstance.set(any(), any()));
-    }
-
-    @Test
     void serviceInit_requestHandlerIsAdded() {
         ServiceInitEvent serviceInitEvent = mock(ServiceInitEvent.class);
 
@@ -122,10 +114,10 @@ public class ClusterSupportTest {
 
         when(vaadinRequest.getHeader(ClusterSupport.UPDATE_VERSION_HEADER))
                 .thenReturn(null);
-        when(vaadinRequest.getWrappedSession()).thenReturn(wrappedSession);
         vaadinRequestMockedStatic.when(VaadinRequest::getCurrent)
                 .thenReturn(vaadinRequest);
         when(vaadinSession.getUIs()).thenReturn(Collections.singletonList(ui));
+        when(vaadinSession.getSession()).thenReturn(wrappedSession);
         when(ui.getChildren()).thenReturn(Stream.of(versionNotifier));
 
         clusterSupport.serviceInit(serviceInitEvent);
@@ -148,7 +140,7 @@ public class ClusterSupportTest {
 
         when(vaadinRequest.getHeader(ClusterSupport.UPDATE_VERSION_HEADER))
                 .thenReturn("");
-        when(vaadinRequest.getWrappedSession()).thenReturn(wrappedSession);
+        when(vaadinSession.getSession()).thenReturn(wrappedSession);
         vaadinRequestMockedStatic.when(VaadinRequest::getCurrent)
                 .thenReturn(vaadinRequest);
         when(vaadinSession.getUIs()).thenReturn(Collections.singletonList(ui));
@@ -174,7 +166,7 @@ public class ClusterSupportTest {
 
         when(vaadinRequest.getHeader(ClusterSupport.UPDATE_VERSION_HEADER))
                 .thenReturn("1.0.0");
-        when(vaadinRequest.getWrappedSession()).thenReturn(wrappedSession);
+        when(vaadinSession.getSession()).thenReturn(wrappedSession);
         vaadinRequestMockedStatic.when(VaadinRequest::getCurrent)
                 .thenReturn(vaadinRequest);
         when(vaadinSession.getUIs()).thenReturn(Collections.singletonList(ui));
@@ -200,7 +192,7 @@ public class ClusterSupportTest {
 
         when(vaadinRequest.getHeader(ClusterSupport.UPDATE_VERSION_HEADER))
                 .thenReturn("2.0.0");
-        when(vaadinRequest.getWrappedSession()).thenReturn(wrappedSession);
+        when(vaadinSession.getSession()).thenReturn(wrappedSession);
         vaadinRequestMockedStatic.when(VaadinRequest::getCurrent)
                 .thenReturn(vaadinRequest);
         when(vaadinSession.getUIs()).thenReturn(Collections.singletonList(ui));
@@ -225,7 +217,7 @@ public class ClusterSupportTest {
 
         when(vaadinRequest.getHeader(ClusterSupport.UPDATE_VERSION_HEADER))
                 .thenReturn("2.0.0");
-        when(vaadinRequest.getWrappedSession()).thenReturn(wrappedSession);
+        when(vaadinSession.getSession()).thenReturn(wrappedSession);
         vaadinRequestMockedStatic.when(VaadinRequest::getCurrent)
                 .thenReturn(vaadinRequest);
         when(vaadinSession.getUIs()).thenReturn(Collections.singletonList(ui));
@@ -243,7 +235,7 @@ public class ClusterSupportTest {
     }
 
     @ParameterizedTest(name = "{index} And_IfNodeSwitchIs_{0}_doAppCleanupIsCalled_{1}_times")
-    @CsvSource({ "true, 1, 1, 2, 1", "false, 0, 0, 1, 0" })
+    @CsvSource({ "true, 1, 1, 1, 1", "false, 0, 0, 0, 0" })
     void onComponentEvent_removesStickyClusterCookieAndInvalidatesSession(
             boolean nodeSwitch, int doAppCleanupTimes, int addCookieTimes,
             int getWrappedSessionTimes, int invalidateTimes)
@@ -257,11 +249,12 @@ public class ClusterSupportTest {
 
         when(vaadinRequest.getHeader(ClusterSupport.UPDATE_VERSION_HEADER))
                 .thenReturn("2.0.0");
-        when(vaadinRequest.getWrappedSession()).thenReturn(wrappedSession);
         vaadinRequestMockedStatic.when(VaadinRequest::getCurrent)
                 .thenReturn(vaadinRequest);
         vaadinResponseMockedStatic.when(VaadinResponse::getCurrent)
                 .thenReturn(vaadinResponse);
+        when(vaadinRequest.getWrappedSession()).thenReturn(wrappedSession);
+        when(vaadinSession.getSession()).thenReturn(wrappedSession);
         when(vaadinSession.getUIs()).thenReturn(Collections.singletonList(ui));
         when(ui.getChildren()).thenReturn(Stream.empty());
         when(switchVersionListener.nodeSwitch(any(), any()))


### PR DESCRIPTION
## Description

VaadinRequest thread local is not available during a VaadinSession.access execution. VaadinRequest is used to access the HTTP session wrapper, that can be obtained through VaadinSession. The most important usage is however getting the update version header, but the lookup can be done outside the access block. This change also removes ClusterSupport registration in CurrentInstance becuase it seems not to be used anywhere and furhtermore the thread local is set only on the thread that calls serviceInit and never cleaned up.

Fixes #148

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
