### PR TITLE
fix: prevent NPE in serialization debug

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
@@ -35,7 +35,9 @@ class DebugBackendConnector implements BackendConnector,
 
     @Override
     public void sendSession(SessionInfo sessionInfo) {
-        serializedSessions.put(sessionInfo.getClusterKey(), sessionInfo);
+        if (sessionInfo != null) {
+            serializedSessions.put(sessionInfo.getClusterKey(), sessionInfo);
+        }
     }
 
     @Override


### PR DESCRIPTION
In case of serialization failure, the debug backend connector can receive a null SessionInfo object, but the missing null check may interrupt the process preventing the job lock to be released early, causing false timeouts.