### PR TITLE
feat: allow configuration of custom cluster cookie name

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
@@ -173,9 +173,10 @@ public class KubernetesKitConfiguration {
         }
 
         @Bean
-        PushSessionTracker pushSendListener(
-                SessionSerializer sessionSerializer) {
-            return new PushSessionTracker(sessionSerializer);
+        PushSessionTracker pushSendListener(SessionSerializer sessionSerializer,
+                KubernetesKitProperties properties) {
+            return new PushSessionTracker(sessionSerializer,
+                    properties.getClusterKeyCookieName());
         }
 
     }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitProperties.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitProperties.java
@@ -11,6 +11,7 @@ package com.vaadin.kubernetes.starter;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import com.vaadin.kubernetes.starter.sessiontracker.CurrentKey;
 import com.vaadin.kubernetes.starter.sessiontracker.SameSite;
 
 /**
@@ -31,6 +32,11 @@ public class KubernetesKitProperties {
      * Enables (or disables) auto-configuration.
      */
     private boolean autoConfigure = true;
+
+    /**
+     * The name of the distributed storage session key cookie.
+     */
+    private String clusterKeyCookieName = CurrentKey.COOKIE_NAME;
 
     /**
      * Value of the distributed storage session key cookie's SameSite attribute.
@@ -62,6 +68,25 @@ public class KubernetesKitProperties {
      */
     public void setAutoConfigure(boolean autoConfigure) {
         this.autoConfigure = autoConfigure;
+    }
+
+    /**
+     * Gets the name of the distributed storage session key cookie.
+     *
+     * @return the name of the distributed storage session key cookie
+     */
+    public String getClusterKeyCookieName() {
+        return clusterKeyCookieName;
+    }
+
+    /**
+     * Sets the name of the distributed storage session key cookie.
+     *
+     * @param clusterKeyCookieName
+     *            the name of the distributed storage session key cookie
+     */
+    public void setClusterKeyCookieName(String clusterKeyCookieName) {
+        this.clusterKeyCookieName = clusterKeyCookieName;
     }
 
     /**

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerFilter.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerFilter.java
@@ -61,7 +61,8 @@ public class SessionTrackerFilter extends HttpFilter {
     protected void doFilter(HttpServletRequest request,
             HttpServletResponse response, FilterChain chain)
             throws IOException, ServletException {
-        SessionTrackerCookie.getValue(request).ifPresent(key -> {
+        String cookieName = properties.getClusterKeyCookieName();
+        SessionTrackerCookie.getValue(request, cookieName).ifPresent(key -> {
             CurrentKey.set(key);
             if (request.getSession(false) == null) {
                 // Cluster key set but no session, create one, so it can be
@@ -74,7 +75,7 @@ public class SessionTrackerFilter extends HttpFilter {
             HttpSession session = request.getSession(false);
 
             SessionTrackerCookie.setIfNeeded(session, request, response,
-                    cookieConsumer(request));
+                    cookieName, cookieConsumer(request));
             super.doFilter(request, response, chain);
 
             if (session != null && request.isRequestedSessionIdValid()

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/push/PushSessionTracker.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/push/PushSessionTracker.java
@@ -37,9 +37,22 @@ public class PushSessionTracker implements PushSendListener {
     private final SessionSerializer sessionSerializer;
 
     private Predicate<String> activeSessionChecker = id -> true;
+    private String clusterCookieName;
 
+    /**
+     * @deprecated use {@link #PushSessionTracker(SessionSerializer, String)}
+     *             instead
+     */
+    @Deprecated(forRemoval = true)
     public PushSessionTracker(SessionSerializer sessionSerializer) {
         this.sessionSerializer = sessionSerializer;
+        this.clusterCookieName = CurrentKey.COOKIE_NAME;
+    }
+
+    public PushSessionTracker(SessionSerializer sessionSerializer,
+            String clusterCookieName) {
+        this.sessionSerializer = sessionSerializer;
+        this.clusterCookieName = clusterCookieName;
     }
 
     /**
@@ -106,7 +119,8 @@ public class PushSessionTracker implements PushSendListener {
         if (key == null) {
             try {
                 key = SessionTrackerCookie
-                        .getValue(resource.getRequest().wrappedRequest())
+                        .getValue(resource.getRequest().wrappedRequest(),
+                                clusterCookieName)
                         .orElse(null);
             } catch (Exception ex) {
                 getLogger().debug("Cannot get serialization key from request",

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerCookieTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerCookieTest.java
@@ -1,13 +1,14 @@
 package com.vaadin.kubernetes.starter.sessiontracker;
 
-import java.util.Optional;
-import java.util.UUID;
-import java.util.function.Consumer;
-
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,6 +23,8 @@ import static org.mockito.Mockito.when;
 
 public class SessionTrackerCookieTest {
 
+    public static final String CLUSTER_COOKIE_NAME = "MY_CLUSTER_COOKIE";
+
     @Test
     void setIfNeeded_nullCookies_attributeIsSetAndCookieIsConfigured() {
         HttpSession session = mock(HttpSession.class);
@@ -33,7 +36,7 @@ public class SessionTrackerCookieTest {
                 Consumer.class);
 
         SessionTrackerCookie.setIfNeeded(session, request, response,
-                cookieConsumer);
+                CLUSTER_COOKIE_NAME, cookieConsumer);
 
         verify(session).setAttribute(eq(CurrentKey.COOKIE_NAME), anyString());
         verify(cookieConsumer).accept(any());
@@ -51,7 +54,7 @@ public class SessionTrackerCookieTest {
                 Consumer.class);
 
         SessionTrackerCookie.setIfNeeded(session, request, response,
-                cookieConsumer);
+                CLUSTER_COOKIE_NAME, cookieConsumer);
 
         verify(session).setAttribute(eq(CurrentKey.COOKIE_NAME), anyString());
         verify(cookieConsumer).accept(any());
@@ -65,14 +68,14 @@ public class SessionTrackerCookieTest {
         HttpSession session = mock(HttpSession.class);
         when(session.getAttribute(anyString())).thenReturn(null);
         HttpServletRequest request = mock(HttpServletRequest.class);
-        when(request.getCookies()).thenReturn(new Cookie[] {
-                new Cookie(CurrentKey.COOKIE_NAME, clusterKey) });
+        when(request.getCookies()).thenReturn(
+                new Cookie[] { new Cookie(CLUSTER_COOKIE_NAME, clusterKey) });
         HttpServletResponse response = mock(HttpServletResponse.class);
         Consumer<Cookie> cookieConsumer = (Cookie cookie) -> {
         };
 
         SessionTrackerCookie.setIfNeeded(session, request, response,
-                cookieConsumer);
+                CLUSTER_COOKIE_NAME, cookieConsumer);
 
         verify(session).setAttribute(eq(CurrentKey.COOKIE_NAME),
                 eq(clusterKey));
@@ -86,14 +89,14 @@ public class SessionTrackerCookieTest {
         HttpSession session = mock(HttpSession.class);
         when(session.getAttribute(anyString())).thenReturn("foo");
         HttpServletRequest request = mock(HttpServletRequest.class);
-        when(request.getCookies()).thenReturn(new Cookie[] {
-                new Cookie(CurrentKey.COOKIE_NAME, clusterKey) });
+        when(request.getCookies()).thenReturn(
+                new Cookie[] { new Cookie(CLUSTER_COOKIE_NAME, clusterKey) });
         HttpServletResponse response = mock(HttpServletResponse.class);
         Consumer<Cookie> cookieConsumer = (Cookie cookie) -> {
         };
 
         SessionTrackerCookie.setIfNeeded(session, request, response,
-                cookieConsumer);
+                CLUSTER_COOKIE_NAME, cookieConsumer);
 
         verify(session, never()).setAttribute(any(), any());
         verify(response, never()).addCookie(any());
@@ -113,7 +116,8 @@ public class SessionTrackerCookieTest {
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getCookies()).thenReturn(null);
 
-        Optional<String> value = SessionTrackerCookie.getValue(request);
+        Optional<String> value = SessionTrackerCookie.getValue(request,
+                CLUSTER_COOKIE_NAME);
 
         verify(request).getCookies();
         assertEquals(Optional.empty(), value);
@@ -124,7 +128,8 @@ public class SessionTrackerCookieTest {
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getCookies()).thenReturn(new Cookie[0]);
 
-        Optional<String> value = SessionTrackerCookie.getValue(request);
+        Optional<String> value = SessionTrackerCookie.getValue(request,
+                CLUSTER_COOKIE_NAME);
 
         verify(request).getCookies();
         assertTrue(value.isEmpty());
@@ -135,16 +140,16 @@ public class SessionTrackerCookieTest {
         String clusterKey = UUID.randomUUID().toString();
 
         HttpServletRequest request = mock(HttpServletRequest.class);
-        when(request.getCookies()).thenReturn(new Cookie[] {
-                new Cookie(CurrentKey.COOKIE_NAME, clusterKey) });
+        when(request.getCookies()).thenReturn(
+                new Cookie[] { new Cookie(CLUSTER_COOKIE_NAME, clusterKey) });
 
-        Optional<String> value = SessionTrackerCookie.getValue(request);
+        Optional<String> value = SessionTrackerCookie.getValue(request,
+                CLUSTER_COOKIE_NAME);
 
         verify(request).getCookies();
         assertTrue(value.isPresent());
         assertEquals(clusterKey, value.get());
     }
-
 
     @Test
     void setIfNeeded_nullCookiesAndSession_cookieIsConfigured() {
@@ -156,11 +161,10 @@ public class SessionTrackerCookieTest {
                 Consumer.class);
 
         SessionTrackerCookie.setIfNeeded(null, request, response,
-                cookieConsumer);
+                CLUSTER_COOKIE_NAME, cookieConsumer);
 
         verify(cookieConsumer).accept(any());
         verify(response).addCookie(any());
     }
-
 
 }

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerFilterTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerFilterTest.java
@@ -26,6 +26,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -143,7 +145,8 @@ class SessionTrackerFilterTest {
                 SessionTrackerCookie.class)) {
             filter.doFilter(request, response, filterChain);
             mockedStatic.verify(() -> SessionTrackerCookie.setIfNeeded(any(),
-                    any(), any(), cookieConsumerArgumentCaptor.capture()));
+                    any(), any(), anyString(),
+                    cookieConsumerArgumentCaptor.capture()));
             Consumer<Cookie> cookieConsumer = cookieConsumerArgumentCaptor
                     .getValue();
             cookieConsumer.accept(cookie);

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/push/PushSessionTrackerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/push/PushSessionTrackerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 
 class PushSessionTrackerTest {
 
+    public static final String CLUSTER_COOKIE_NAME = "MY_COOKIE_NAME";
     private HttpSession httpSession;
     private HttpServletRequest servletRequest;
     private SessionSerializer sessionSerializer;
@@ -38,7 +39,8 @@ class PushSessionTrackerTest {
         httpSession = mock(HttpSession.class);
         servletRequest = mock(HttpServletRequest.class);
         sessionSerializer = mock(SessionSerializer.class);
-        sessionTracker = new PushSessionTracker(sessionSerializer);
+        sessionTracker = new PushSessionTracker(sessionSerializer,
+                CLUSTER_COOKIE_NAME);
         sessionTracker.setActiveSessionChecker(id -> true);
     }
 
@@ -67,8 +69,8 @@ class PushSessionTrackerTest {
     void onConnect_clusterKeyFromCookie_storeClusterKeyOnResourceSession() {
         AtmosphereResource resource = createResource(null);
         String clusterKey = UUID.randomUUID().toString();
-        when(servletRequest.getCookies()).thenReturn(new Cookie[] {
-                new Cookie(CurrentKey.COOKIE_NAME, clusterKey) });
+        when(servletRequest.getCookies()).thenReturn(
+                new Cookie[] { new Cookie(CLUSTER_COOKIE_NAME, clusterKey) });
 
         sessionTracker.onConnect(resource);
 


### PR DESCRIPTION
## Description

Allows to set a custom name for the cluster key cookie by setting the `vaadin.kubernetes.cluster-key-cookie-name` property in `application.properties`.

Fixes #145 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
