### PR TITLE
feat: add configurable backend session expiration policy

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitProperties.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitProperties.java
@@ -9,6 +9,8 @@
  */
 package com.vaadin.kubernetes.starter;
 
+import java.time.Duration;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import com.vaadin.kubernetes.starter.sessiontracker.CurrentKey;
@@ -32,6 +34,12 @@ public class KubernetesKitProperties {
      * Enables (or disables) auto-configuration.
      */
     private boolean autoConfigure = true;
+
+    /**
+     * Amount of time to be added to the HTTP session timeout to determine the
+     * expiration of the backend session.
+     */
+    private Duration backendSessionExpirationTolerance;
 
     /**
      * The name of the distributed storage session key cookie.
@@ -68,6 +76,23 @@ public class KubernetesKitProperties {
      */
     public void setAutoConfigure(boolean autoConfigure) {
         this.autoConfigure = autoConfigure;
+    }
+
+    /**
+     * Sets the amount of time to be added to the HTTP session timeout to
+     * determine the expiration of the backend session.
+     */
+    public void setBackendSessionExpirationTolerance(
+            Duration backendSessionExpirationTolerance) {
+        this.backendSessionExpirationTolerance = backendSessionExpirationTolerance;
+    }
+
+    /**
+     * Gets the amount of time to be added to the HTTP session timeout to
+     * determine the expiration of the backend session.
+     */
+    public Duration getBackendSessionExpirationTolerance() {
+        return backendSessionExpirationTolerance;
     }
 
     /**

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnector.java
@@ -9,6 +9,7 @@
  */
 package com.vaadin.kubernetes.starter.sessiontracker.backend;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import com.hazelcast.core.HazelcastInstance;
@@ -35,7 +36,14 @@ public class HazelcastConnector implements BackendConnector {
         getLogger().debug("Sending session {} to Hazelcast",
                 sessionInfo.getClusterKey());
         String mapKey = getKey(sessionInfo.getClusterKey());
-        sessions.put(mapKey, sessionInfo.getData());
+        Duration timeToLive = sessionInfo.getTimeToLive();
+        if (timeToLive.isZero() || timeToLive.isNegative()) {
+            sessions.put(mapKey, sessionInfo.getData());
+        } else {
+            sessions.put(mapKey, sessionInfo.getData(), timeToLive.toSeconds(),
+                    TimeUnit.SECONDS);
+        }
+
         getLogger().debug("Session {} sent to Hazelcast",
                 sessionInfo.getClusterKey());
     }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/SessionExpirationPolicy.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/SessionExpirationPolicy.java
@@ -1,0 +1,32 @@
+package com.vaadin.kubernetes.starter.sessiontracker.backend;
+
+import java.time.Duration;
+
+/**
+ * A rule that determines the expiration for a backend session based on the
+ * current HTTP session timeout.
+ */
+public interface SessionExpirationPolicy {
+
+    /**
+     * Computes the maximum amount of time an inactive session should be
+     * preserved in the backed, based on the given HTTP session timeout
+     * expressed in seconds.
+     * <p>
+     * </p>
+     * A return value of {@link Duration#ZERO} or less means the backend session
+     * should never expire.
+     * 
+     * @param sessionTimeout
+     *            HTTP session timeout expressed in seconds.
+     * @return the maximum amount of time an inactive session should be
+     *         preserved in the backed.
+     */
+    Duration apply(long sessionTimeout);
+
+    /**
+     * A policy that prevents expiration.
+     */
+    SessionExpirationPolicy NEVER = sessionTimeout -> Duration.ZERO;
+
+}

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/SessionInfo.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/SessionInfo.java
@@ -9,12 +9,15 @@
  */
 package com.vaadin.kubernetes.starter.sessiontracker.backend;
 
+import java.time.Duration;
+
 /**
  * Holder for serialized session attributes.
  */
 public class SessionInfo {
     private final String clusterKey;
     private final byte[] data;
+    private final Duration timeToLive;
 
     /**
      * Creates a new {@link SessionInfo} for the given distributed storage key.
@@ -27,6 +30,25 @@ public class SessionInfo {
     public SessionInfo(String clusterKey, byte[] data) {
         this.clusterKey = clusterKey;
         this.data = data;
+        this.timeToLive = Duration.ZERO;
+    }
+
+    /**
+     * Creates a new {@link SessionInfo} for the given distributed storage key.
+     *
+     * @param clusterKey
+     *            the distributed storage key.
+     * @param timeToLive
+     *            the maximum amount of time an inactive session should be
+     *            preserved in the backed. A zero or negative value means the
+     *            session should not be evicted.
+     * @param data
+     *            serialized session attributes in binary format.
+     */
+    public SessionInfo(String clusterKey, Duration timeToLive, byte[] data) {
+        this.clusterKey = clusterKey;
+        this.data = data;
+        this.timeToLive = timeToLive;
     }
 
     /**
@@ -47,4 +69,14 @@ public class SessionInfo {
         return data;
     }
 
+    /**
+     * Gets the maximum amount of time an inactive session should be preserved
+     * in the backed. A zero or negative value means the session should not be
+     * evicted.
+     * 
+     * @return the session time to live.
+     */
+    public Duration getTimeToLive() {
+        return timeToLive;
+    }
 }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
@@ -49,6 +49,7 @@ import com.vaadin.kubernetes.starter.SerializationProperties;
 import com.vaadin.kubernetes.starter.sessiontracker.CurrentKey;
 import com.vaadin.kubernetes.starter.sessiontracker.SessionSerializationCallback;
 import com.vaadin.kubernetes.starter.sessiontracker.SessionSerializer;
+import com.vaadin.kubernetes.starter.sessiontracker.backend.SessionExpirationPolicy;
 import com.vaadin.kubernetes.starter.sessiontracker.backend.SessionInfo;
 import com.vaadin.kubernetes.starter.ui.SessionDebugNotifier;
 
@@ -103,7 +104,8 @@ public class SerializationDebugRequestHandler
         this.serializationProperties = serializationProperties;
         this.debugBackendConnector = new DebugBackendConnector();
         this.sessionSerializer = new SessionSerializer(debugBackendConnector,
-                debugBackendConnector, SessionSerializationCallback.DEFAULT);
+                debugBackendConnector, SessionExpirationPolicy.NEVER,
+                SessionSerializationCallback.DEFAULT);
     }
 
     @Override

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/KubernetesKitConfigurationTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/KubernetesKitConfigurationTest.java
@@ -9,9 +9,14 @@
  */
 package com.vaadin.kubernetes.starter;
 
+import java.time.Duration;
+
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import com.vaadin.kubernetes.starter.sessiontracker.backend.SessionExpirationPolicy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -20,6 +25,28 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class KubernetesKitConfigurationTest {
+
+    @Test
+    public void sessionExpirationPolicy_configNotSet_policyIsNever() {
+        var prop = new KubernetesKitProperties();
+        var cfg = new KubernetesKitConfiguration.VaadinReplicatedSessionConfiguration(
+                prop);
+        var sessionExpirationPolicy = cfg.sessionExpirationPolicy();
+        Assertions.assertSame(sessionExpirationPolicy,
+                SessionExpirationPolicy.NEVER);
+    }
+
+    @Test
+    public void sessionExpirationPolicy_configSet_policyIsSessionTimeoutPlusTolerance() {
+        var prop = new KubernetesKitProperties();
+        prop.setBackendSessionExpirationTolerance(Duration.ofMinutes(10));
+        var cfg = new KubernetesKitConfiguration.VaadinReplicatedSessionConfiguration(
+                prop);
+        var sessionExpirationPolicy = cfg.sessionExpirationPolicy();
+        assertEquals(Duration.ofMinutes(40),
+                sessionExpirationPolicy.apply(1800));
+
+    }
 
     @Test
     public void hazelcastInstance_serviceNameSet_kubernetesConfigured() {

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializerTest.java
@@ -4,6 +4,8 @@ import jakarta.servlet.http.HttpSession;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -19,6 +21,7 @@ import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockHttpSession;
 
 import com.vaadin.flow.function.DeploymentConfiguration;
@@ -69,6 +72,8 @@ class SessionSerializerTest {
         connector = mock(BackendConnector.class);
         transientHandler = mock(TransientHandler.class);
         serializer = new SessionSerializer(connector, transientHandler,
+                sessionTimeout -> Duration.ofSeconds(sessionTimeout).plus(5,
+                        ChronoUnit.MINUTES),
                 serializationCallback,
                 TEST_OPTIMISTIC_SERIALIZATION_TIMEOUT_MS);
 
@@ -81,6 +86,7 @@ class SessionSerializerTest {
 
     private static HttpSession newHttpSession(String clusterSID) {
         HttpSession httpSession = new MockHttpSession();
+        httpSession.setMaxInactiveInterval(1800);
         httpSession.setAttribute(CurrentKey.COOKIE_NAME, clusterSID);
         return httpSession;
     }
@@ -101,7 +107,13 @@ class SessionSerializerTest {
         verify(connector).markSerializationStarted(clusterSID);
 
         await().atMost(1000, MILLISECONDS).untilTrue(serializationCompleted);
-        verify(connector).sendSession(notNull());
+        ArgumentCaptor<SessionInfo> sessionInfoCaptor = ArgumentCaptor
+                .forClass(SessionInfo.class);
+        verify(connector).sendSession(sessionInfoCaptor.capture());
+        SessionInfo sessionInfo = sessionInfoCaptor.getValue();
+        Assertions.assertNotNull(sessionInfo);
+        Assertions.assertEquals(Duration.ofMinutes(35),
+                sessionInfo.getTimeToLive());
     }
 
     @Test

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnectorTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnectorTest.java
@@ -1,14 +1,18 @@
 package com.vaadin.kubernetes.starter.sessiontracker.backend;
 
+import java.time.Duration;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStringCommands;
+import org.springframework.data.redis.core.types.Expiration;
 
 import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,15 +37,26 @@ public class RedisConnectorTest {
 
     @Test
     void sendSession_sessionIsAdded() {
-        SessionInfo sessionInfo = mock(SessionInfo.class);
-        when(sessionInfo.getClusterKey()).thenReturn(clusterKey);
-        byte[] data = new byte[] { 'f', 'o', 'o' };
-        when(sessionInfo.getData()).thenReturn(data);
+        SessionInfo sessionInfo = new SessionInfo(clusterKey,
+                new byte[] { 'f', 'o', 'o' });
 
         connector.sendSession(sessionInfo);
 
         verify(connection).set(aryEq(RedisConnector.getKey(clusterKey)),
-                aryEq(data));
+                aryEq(sessionInfo.getData()));
+    }
+
+    @Test
+    void sendSession_expiration_sessionIsAddedWithTimeToLive() {
+        SessionInfo sessionInfo = new SessionInfo(clusterKey,
+                Duration.ofMinutes(30), new byte[] { 'f', 'o', 'o' });
+
+        connector.sendSession(sessionInfo);
+
+        verify(connection).set(aryEq(RedisConnector.getKey(clusterKey)),
+                aryEq(sessionInfo.getData()),
+                eq(Expiration.from(sessionInfo.getTimeToLive())),
+                eq(RedisStringCommands.SetOption.UPSERT));
     }
 
     @Test

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/SessionInfoTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/SessionInfoTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.kubernetes.starter.sessiontracker.backend;
 
+import java.time.Duration;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -11,10 +12,13 @@ public class SessionInfoTest {
     void construct_attributesAreSet() {
         String clusterKey = UUID.randomUUID().toString();
         byte[] data = new byte[] { 'f', 'o', 'o' };
+        int timeout = 10;
 
-        SessionInfo sessionInfo = new SessionInfo(clusterKey, data);
+        SessionInfo sessionInfo = new SessionInfo(clusterKey,
+                Duration.ofSeconds(10), data);
 
         assertEquals(clusterKey, sessionInfo.getClusterKey());
         assertEquals(data, sessionInfo.getData());
+        assertEquals(Duration.ofSeconds(timeout), sessionInfo.getTimeToLive());
     }
 }


### PR DESCRIPTION
## Description

Allows to define an expiration policy for the backend stored session. By default no expiration is set, but can be expiration can be activated setting the vaadin.kubernetes.backend-session-expiration-tolerance property or by providing a custom SessionExpirationPolicy bean.

Fixes #126

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
