### PR TITLE
fix: demo application build

### DIFF
--- a/kubernetes-kit-demo/pom.xml
+++ b/kubernetes-kit-demo/pom.xml
@@ -48,6 +48,12 @@
             <groupId>com.github.javafaker</groupId>
             <artifactId>javafaker</artifactId>
             <version>1.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>


### PR DESCRIPTION
The demo application build and because of this all PR builds fail with
`[ERROR] Failed to execute goal com.vaadin:flow-maven-plugin:24.5-SNAPSHOT:prepare-frontend (default) on project kubernetes-kit-demo: Execution default of goal com.vaadin:flow-maven-plugin:24.5-SNAPSHOT:prepare-frontend failed: Duplicate key org.yaml:snakeyaml (attempted merging values org.yaml:snakeyaml:jar:2.2:compile and org.yaml:snakeyaml:jar:android:1.23:compile) -> [Help 1]`
because of the duplicate `snakeyaml` dependency.

Excluding the `snakeyaml` from the `javafaker` dependency fixes this issue.