### PR TITLE
Adds pluggable SerializationStreamFactory

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
@@ -46,9 +46,10 @@ import com.vaadin.kubernetes.starter.ProductUtils;
 import com.vaadin.kubernetes.starter.sessiontracker.backend.BackendConnector;
 import com.vaadin.kubernetes.starter.sessiontracker.backend.SessionExpirationPolicy;
 import com.vaadin.kubernetes.starter.sessiontracker.backend.SessionInfo;
+import com.vaadin.kubernetes.starter.sessiontracker.serialization.SerializationInputStream;
+import com.vaadin.kubernetes.starter.sessiontracker.serialization.SerializationOutputStream;
+import com.vaadin.kubernetes.starter.sessiontracker.serialization.SerializationStreamFactory;
 import com.vaadin.kubernetes.starter.sessiontracker.serialization.TransientHandler;
-import com.vaadin.kubernetes.starter.sessiontracker.serialization.TransientInjectableObjectInputStream;
-import com.vaadin.kubernetes.starter.sessiontracker.serialization.TransientInjectableObjectOutputStream;
 
 /**
  * Component responsible for replicating HTTP session attributes to a
@@ -127,6 +128,8 @@ public class SessionSerializer
 
     private final SessionExpirationPolicy sessionExpirationPolicy;
 
+    private final SerializationStreamFactory serializationStreamFactory;
+
     private Predicate<Class<?>> injectableFilter = type -> true;
 
     /**
@@ -142,11 +145,12 @@ public class SessionSerializer
      *            when an error happens
      */
     public SessionSerializer(BackendConnector backendConnector,
-            TransientHandler transientHandler,
-            SessionExpirationPolicy sessionExpirationPolicy,
-            SessionSerializationCallback sessionSerializationCallback) {
+                             TransientHandler transientHandler,
+                             SessionExpirationPolicy sessionExpirationPolicy,
+                             SessionSerializationCallback sessionSerializationCallback,
+                             SerializationStreamFactory serializationStreamFactory) {
         this(backendConnector, (sessionId, clusterKey) -> transientHandler,
-                sessionExpirationPolicy, sessionSerializationCallback);
+                sessionExpirationPolicy, sessionSerializationCallback, serializationStreamFactory);
     }
 
     /**
@@ -175,27 +179,31 @@ public class SessionSerializer
      *            when an error happens
      */
     public SessionSerializer(BackendConnector backendConnector,
-            BiFunction<String, String, TransientHandler> transientHandlerProvider,
-            SessionExpirationPolicy sessionExpirationPolicy,
-            SessionSerializationCallback sessionSerializationCallback) {
+                             BiFunction<String, String, TransientHandler> transientHandlerProvider,
+                             SessionExpirationPolicy sessionExpirationPolicy,
+                             SessionSerializationCallback sessionSerializationCallback,
+                             SerializationStreamFactory serializationStreamFactory) {
         this.backendConnector = backendConnector;
         this.handlerProvider = transientHandlerProvider;
         this.sessionSerializationCallback = sessionSerializationCallback;
         this.sessionExpirationPolicy = sessionExpirationPolicy;
+        this.serializationStreamFactory = serializationStreamFactory;
         optimisticSerializationTimeoutMs = OPTIMISTIC_SERIALIZATION_TIMEOUT_MS;
     }
 
     // Visible for test
     SessionSerializer(BackendConnector backendConnector,
-            TransientHandler transientHandler,
-            SessionExpirationPolicy sessionExpirationPolicy,
-            SessionSerializationCallback sessionSerializationCallback,
-            long optimisticSerializationTimeoutMs) {
+                      TransientHandler transientHandler,
+                      SessionExpirationPolicy sessionExpirationPolicy,
+                      SessionSerializationCallback sessionSerializationCallback,
+                      long optimisticSerializationTimeoutMs,
+                      SerializationStreamFactory serializationStreamFactory) {
         this.backendConnector = backendConnector;
         this.optimisticSerializationTimeoutMs = optimisticSerializationTimeoutMs;
         this.sessionSerializationCallback = sessionSerializationCallback;
         this.sessionExpirationPolicy = sessionExpirationPolicy;
         this.handlerProvider = (sessionId, clusterKey) -> transientHandler;
+        this.serializationStreamFactory = serializationStreamFactory;
     }
 
     /**
@@ -505,9 +513,8 @@ public class SessionSerializer
         long start = System.currentTimeMillis();
         String clusterKey = getClusterKey(attributes);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        try (TransientInjectableObjectOutputStream outStream = TransientInjectableObjectOutputStream
-                .newInstance(out, handlerProvider.apply(sessionId, clusterKey),
-                        injectableFilter)) {
+        TransientHandler transientHandler = handlerProvider.apply(sessionId, clusterKey);
+        try (SerializationOutputStream outStream = serializationStreamFactory.createOutputStream(out, transientHandler, injectableFilter)) {
             outStream.writeWithTransients(attributes);
             sessionSerializationCallback.onSerializationSuccess();
         } catch (Exception ex) {
@@ -539,9 +546,9 @@ public class SessionSerializer
                 .getContextClassLoader();
         ByteArrayInputStream in = new ByteArrayInputStream(data);
         Map<String, Object> attributes;
-        try (TransientInjectableObjectInputStream inStream = new TransientInjectableObjectInputStream(
-                in, handlerProvider.apply(sessionId,
-                        sessionInfo.getClusterKey()))) {
+        TransientHandler transientHandler = handlerProvider.apply(sessionId, sessionInfo.getClusterKey());
+
+        try (SerializationInputStream inStream = serializationStreamFactory.createInputStream(in, transientHandler)) {
             attributes = inStream.readWithTransients();
             sessionSerializationCallback.onDeserializationSuccess();
         } catch (Exception ex) {

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/SerializationInputStream.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/SerializationInputStream.java
@@ -1,0 +1,22 @@
+/*-
+ * Copyright (C) 2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.kubernetes.starter.sessiontracker.serialization;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+
+public abstract class SerializationInputStream extends ObjectInputStream {
+    public SerializationInputStream(InputStream in) throws IOException {
+        super(in);
+    }
+
+    public abstract <T> T readWithTransients() throws IOException, ClassNotFoundException;
+}

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/SerializationOutputStream.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/SerializationOutputStream.java
@@ -1,0 +1,22 @@
+/*-
+ * Copyright (C) 2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.kubernetes.starter.sessiontracker.serialization;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+
+public abstract class SerializationOutputStream extends ObjectOutputStream {
+    public SerializationOutputStream(OutputStream out) throws IOException {
+        super(out);
+    }
+
+    public abstract void writeWithTransients(Object object) throws IOException;
+}

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/SerializationStreamFactory.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/SerializationStreamFactory.java
@@ -1,0 +1,26 @@
+/*-
+ * Copyright (C) 2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.kubernetes.starter.sessiontracker.serialization;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.function.Predicate;
+
+/**
+ * Factory that is used to create new input / output streams for session (de-)serialization.
+ *
+ * @see TransientInjectableObjectStreamFactory
+ **/
+public interface SerializationStreamFactory {
+    SerializationOutputStream createOutputStream(OutputStream baseOutputStream, TransientHandler transientHandler, Predicate<Class<?>> injectableFilter) throws IOException;
+
+    SerializationInputStream createInputStream(InputStream in, TransientHandler transientHandler) throws IOException;
+}

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/TransientInjectableObjectInputStream.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/TransientInjectableObjectInputStream.java
@@ -45,7 +45,7 @@ import com.vaadin.kubernetes.starter.sessiontracker.serialization.debug.Track;
  * @see TransientHandler
  * @see TransientDescriptor
  */
-public class TransientInjectableObjectInputStream extends ObjectInputStream {
+public class TransientInjectableObjectInputStream extends SerializationInputStream {
 
     private final VarHandle passHandleHandle;
     private final MethodHandle handlesLookupObjectHandle;
@@ -152,6 +152,7 @@ public class TransientInjectableObjectInputStream extends ObjectInputStream {
     }
 
     @SuppressWarnings("unchecked")
+    @Override
     public <T> T readWithTransients()
             throws IOException, ClassNotFoundException {
         if (injector instanceof DebugMode) {

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/TransientInjectableObjectOutputStream.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/TransientInjectableObjectOutputStream.java
@@ -73,7 +73,7 @@ import com.vaadin.kubernetes.starter.sessiontracker.serialization.debug.Track;
  * @see TransientHandler
  * @see TransientDescriptor
  */
-public class TransientInjectableObjectOutputStream extends ObjectOutputStream {
+public class TransientInjectableObjectOutputStream extends SerializationOutputStream {
 
     static final Pattern INSPECTION_REJECTION_PATTERN = Pattern
             .compile("^(javax?|jakarta|com\\.sun|sun\\.misc)\\..*");
@@ -173,6 +173,7 @@ public class TransientInjectableObjectOutputStream extends ObjectOutputStream {
         }
     }
 
+    @Override
     public void writeWithTransients(Object object) throws IOException {
         inspected.clear();
         tracking.clear();

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/TransientInjectableObjectStreamFactory.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/TransientInjectableObjectStreamFactory.java
@@ -1,0 +1,22 @@
+package com.vaadin.kubernetes.starter.sessiontracker.serialization;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.function.Predicate;
+
+/**
+ * Factory that is used to create new {@link TransientInjectableObjectOutputStream} and
+ * {@link TransientInjectableObjectInputStream} for session (de-)serialization.
+ **/
+public class TransientInjectableObjectStreamFactory implements SerializationStreamFactory {
+    @Override
+    public SerializationOutputStream createOutputStream(OutputStream baseOutputStream, TransientHandler transientHandler, Predicate<Class<?>> injectableFilter) throws IOException {
+        return TransientInjectableObjectOutputStream.newInstance(baseOutputStream, transientHandler, injectableFilter);
+    }
+
+    @Override
+    public SerializationInputStream createInputStream(InputStream in, TransientHandler transientHandler) throws IOException {
+        return new TransientInjectableObjectInputStream(in, transientHandler);
+    }
+}

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
@@ -9,6 +9,7 @@
  */
 package com.vaadin.kubernetes.starter.sessiontracker.serialization.debug;
 
+import com.vaadin.kubernetes.starter.sessiontracker.serialization.TransientInjectableObjectStreamFactory;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
@@ -105,7 +106,7 @@ public class SerializationDebugRequestHandler
         this.debugBackendConnector = new DebugBackendConnector();
         this.sessionSerializer = new SessionSerializer(debugBackendConnector,
                 debugBackendConnector, SessionExpirationPolicy.NEVER,
-                SessionSerializationCallback.DEFAULT);
+                SessionSerializationCallback.DEFAULT, new TransientInjectableObjectStreamFactory());
     }
 
     @Override

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializerTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.kubernetes.starter.sessiontracker;
 
+import com.vaadin.kubernetes.starter.sessiontracker.serialization.TransientInjectableObjectStreamFactory;
 import jakarta.servlet.http.HttpSession;
 
 import java.io.IOException;
@@ -75,7 +76,8 @@ class SessionSerializerTest {
                 sessionTimeout -> Duration.ofSeconds(sessionTimeout).plus(5,
                         ChronoUnit.MINUTES),
                 serializationCallback,
-                TEST_OPTIMISTIC_SERIALIZATION_TIMEOUT_MS);
+                TEST_OPTIMISTIC_SERIALIZATION_TIMEOUT_MS,
+                new TransientInjectableObjectStreamFactory());
 
         clusterSID = UUID.randomUUID().toString();
         httpSession = newHttpSession(clusterSID);


### PR DESCRIPTION
## Description

This pull request introduces a SerializationStreamFactory bean to provide output and input stream instances, enabling the injection of custom implementations. In our project, we use a custom stream implementation to achieve the following objectives:

- Replace the default transient handling logic with custom logic that, by default, does not serialize any referenced spring beans (even if they're not marked as transient, refer to issue #168 for more details)
- Directly write the serialized output to a zstd compression stream, which in our case compresses down the sessions by a factor of six in a few milliseconds
- Add a micrometer timer that measures the time between creating and closing the stream to monitor serialization runtime

Fixes #168

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
