### PR TITLE
fix: ensure SessionTrackerFilter is executed before Spring Security

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
@@ -177,7 +177,7 @@ public class KubernetesKitConfiguration {
                     sessionSerializer);
             pushSessionTracker.setActiveSessionChecker(
                     sessionListener.activeSessionChecker());
-            return new FilterRegistrationBean<>(
+            FilterRegistrationBean<SessionTrackerFilter> registration = new FilterRegistrationBean<>(
                     sessionTrackerFilter(sessionSerializer)) {
                 @Override
                 protected FilterRegistration.Dynamic addRegistration(
@@ -186,6 +186,9 @@ public class KubernetesKitConfiguration {
                     return super.addRegistration(description, servletContext);
                 }
             };
+            registration.setAsyncSupported(true);
+            registration.setOrder(Integer.MIN_VALUE + 50);
+            return registration;
         }
 
         @Bean


### PR DESCRIPTION
Currently, the Spring Security filter chain is executed before SessionTrackerFilter restores the HTTP session, causing Vaadin security checks to fail even if the user information is available in the serialized session. This change fixes the order of the SessionTrackerFilter so that it is always executed before the Spring Security filter chain.

Fixes #170