### PR TITLE
fix: add ttl for peding session key

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -313,6 +314,10 @@ public class SessionSerializer
                 }).whenComplete((unused, error) -> {
                     pending.remove(sessionId);
                     if (error != null) {
+                        if (error instanceof CompletionException
+                                && error.getCause() != null) {
+                            error = error.getCause();
+                        }
                         backendConnector.markSerializationFailed(clusterKey,
                                 error);
                         getLogger().error("Serialization of session {} failed",

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
@@ -313,6 +313,8 @@ public class SessionSerializer
                 }).whenComplete((unused, error) -> {
                     pending.remove(sessionId);
                     if (error != null) {
+                        backendConnector.markSerializationFailed(clusterKey,
+                                error);
                         getLogger().error("Serialization of session {} failed",
                                 sessionId, error);
                     }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
@@ -291,8 +291,8 @@ public class SessionSerializer
         // Current session is immediately marked as 'serialization pending',
         // because if 'markSerializationStarted' is hanging, it does not make
         // sense to retry the operation instantly.
-        CompletableFuture.runAsync(
-                () -> backendConnector.markSerializationStarted(clusterKey),
+        CompletableFuture.runAsync(() -> backendConnector
+                .markSerializationStarted(clusterKey, timeToLive),
                 executorService).handle((unused, error) -> {
                     if (error != null) {
                         getLogger().debug(

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/BackendConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/BackendConnector.java
@@ -18,6 +18,12 @@ public interface BackendConnector {
 
     void deleteSession(String clusterKey);
 
+    /**
+     * @deprecated use {@link #markSerializationStarted(String, Duration)}
+     */
+    @Deprecated(since = "2.4", forRemoval = true)
+    void markSerializationStarted(String clusterKey);
+
     void markSerializationStarted(String clusterKey, Duration timeToLive);
 
     void markSerializationComplete(String clusterKey);

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/BackendConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/BackendConnector.java
@@ -21,4 +21,6 @@ public interface BackendConnector {
     void markSerializationStarted(String clusterKey, Duration timeToLive);
 
     void markSerializationComplete(String clusterKey);
+
+    void markSerializationFailed(String clusterKey, Throwable error);
 }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/BackendConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/BackendConnector.java
@@ -18,12 +18,6 @@ public interface BackendConnector {
 
     void deleteSession(String clusterKey);
 
-    /**
-     * @deprecated use {@link #markSerializationStarted(String, Duration)}
-     */
-    @Deprecated(since = "2.4", forRemoval = true)
-    void markSerializationStarted(String clusterKey);
-
     void markSerializationStarted(String clusterKey, Duration timeToLive);
 
     void markSerializationComplete(String clusterKey);

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/BackendConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/BackendConnector.java
@@ -9,6 +9,8 @@
  */
 package com.vaadin.kubernetes.starter.sessiontracker.backend;
 
+import java.time.Duration;
+
 public interface BackendConnector {
     void sendSession(SessionInfo sessionInfo);
 
@@ -16,7 +18,7 @@ public interface BackendConnector {
 
     void deleteSession(String clusterKey);
 
-    void markSerializationStarted(String clusterKey);
+    void markSerializationStarted(String clusterKey, Duration timeToLive);
 
     void markSerializationComplete(String clusterKey);
 }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnector.java
@@ -66,6 +66,12 @@ public class HazelcastConnector implements BackendConnector {
     }
 
     @Override
+    public void markSerializationStarted(String clusterKey) {
+        getLogger().debug("Marking serialization started for {}", clusterKey);
+        sessions.lock(getPendingKey(clusterKey));
+    }
+
+    @Override
     public void markSerializationStarted(String clusterKey,
             Duration timeToLive) {
         getLogger().debug("Marking serialization started for {}", clusterKey);

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnector.java
@@ -66,9 +66,11 @@ public class HazelcastConnector implements BackendConnector {
     }
 
     @Override
-    public void markSerializationStarted(String clusterKey) {
+    public void markSerializationStarted(String clusterKey,
+            Duration timeToLive) {
         getLogger().debug("Marking serialization started for {}", clusterKey);
-        sessions.lock(getPendingKey(clusterKey));
+        sessions.lock(getPendingKey(clusterKey), timeToLive.toSeconds(),
+                TimeUnit.SECONDS);
     }
 
     @Override

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnector.java
@@ -80,6 +80,13 @@ public class HazelcastConnector implements BackendConnector {
     }
 
     @Override
+    public void markSerializationFailed(String clusterKey, Throwable error) {
+        getLogger().debug("Marking serialization failed for {}", clusterKey,
+                error);
+        sessions.forceUnlock(getPendingKey(clusterKey));
+    }
+
+    @Override
     public void deleteSession(String clusterKey) {
         getLogger().debug("Deleting session {}", clusterKey);
         waitForSerializationCompletion(clusterKey, "deleting");

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnector.java
@@ -69,8 +69,12 @@ public class HazelcastConnector implements BackendConnector {
     public void markSerializationStarted(String clusterKey,
             Duration timeToLive) {
         getLogger().debug("Marking serialization started for {}", clusterKey);
-        sessions.lock(getPendingKey(clusterKey), timeToLive.toSeconds(),
-                TimeUnit.SECONDS);
+        if (timeToLive.isZero() || timeToLive.isNegative()) {
+            sessions.lock(getPendingKey(clusterKey));
+        } else {
+            sessions.lock(getPendingKey(clusterKey), timeToLive.toSeconds(),
+                    TimeUnit.SECONDS);
+        }
     }
 
     @Override

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnector.java
@@ -66,12 +66,6 @@ public class HazelcastConnector implements BackendConnector {
     }
 
     @Override
-    public void markSerializationStarted(String clusterKey) {
-        getLogger().debug("Marking serialization started for {}", clusterKey);
-        sessions.lock(getPendingKey(clusterKey));
-    }
-
-    @Override
     public void markSerializationStarted(String clusterKey,
             Duration timeToLive) {
         getLogger().debug("Marking serialization started for {}", clusterKey);

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnector.java
@@ -80,16 +80,6 @@ public class RedisConnector implements BackendConnector {
     }
 
     @Override
-    public void markSerializationStarted(String clusterKey) {
-        getLogger().debug("Marking serialization started for {}", clusterKey);
-        try (RedisConnection connection = redisConnectionFactory
-                .getConnection()) {
-            connection.set(getPendingKey(clusterKey),
-                    BackendUtil.b("" + System.currentTimeMillis()));
-        }
-    }
-
-    @Override
     public void markSerializationStarted(String clusterKey,
             Duration timeToLive) {
         getLogger().debug("Marking serialization started for {}", clusterKey);

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnector.java
@@ -80,6 +80,16 @@ public class RedisConnector implements BackendConnector {
     }
 
     @Override
+    public void markSerializationStarted(String clusterKey) {
+        getLogger().debug("Marking serialization started for {}", clusterKey);
+        try (RedisConnection connection = redisConnectionFactory
+                .getConnection()) {
+            connection.set(getPendingKey(clusterKey),
+                    BackendUtil.b("" + System.currentTimeMillis()));
+        }
+    }
+
+    @Override
     public void markSerializationStarted(String clusterKey,
             Duration timeToLive) {
         getLogger().debug("Marking serialization started for {}", clusterKey);

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnector.java
@@ -107,6 +107,16 @@ public class RedisConnector implements BackendConnector {
     }
 
     @Override
+    public void markSerializationFailed(String clusterKey, Throwable error) {
+        getLogger().debug("Marking serialization failed for {}", clusterKey,
+                error);
+        try (RedisConnection connection = redisConnectionFactory
+                .getConnection()) {
+            connection.keyCommands().del(getPendingKey(clusterKey));
+        }
+    }
+
+    @Override
     public void deleteSession(String clusterKey) {
         getLogger().debug("Deleting session for {}", clusterKey);
         try (RedisConnection connection = redisConnectionFactory

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
@@ -59,6 +59,11 @@ class DebugBackendConnector implements BackendConnector,
     }
 
     @Override
+    public void markSerializationStarted(String clusterKey) {
+        getJob(clusterKey).serializationStarted();
+    }
+
+    @Override
     public void markSerializationStarted(String clusterKey,
             Duration timeToLive) {
         getJob(clusterKey).serializationStarted();

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
@@ -9,6 +9,7 @@
  */
 package com.vaadin.kubernetes.starter.sessiontracker.serialization.debug;
 
+import java.time.Duration;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -58,7 +59,8 @@ class DebugBackendConnector implements BackendConnector,
     }
 
     @Override
-    public void markSerializationStarted(String clusterKey) {
+    public void markSerializationStarted(String clusterKey,
+            Duration timeToLive) {
         getJob(clusterKey).serializationStarted();
     }
 

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
@@ -71,6 +71,12 @@ class DebugBackendConnector implements BackendConnector,
     }
 
     @Override
+    public void markSerializationFailed(String clusterKey, Throwable error) {
+        Job job = getJob(clusterKey);
+        job.serializationFailed(new Exception(error));
+    }
+
+    @Override
     public TransientHandler apply(String sessionId, String clusterKey) {
         return handlers.computeIfAbsent(getJob(clusterKey),
                 DebugTransientHandler::new);

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/DebugBackendConnector.java
@@ -59,11 +59,6 @@ class DebugBackendConnector implements BackendConnector,
     }
 
     @Override
-    public void markSerializationStarted(String clusterKey) {
-        getJob(clusterKey).serializationStarted();
-    }
-
-    @Override
     public void markSerializationStarted(String clusterKey,
             Duration timeToLive) {
         getJob(clusterKey).serializationStarted();

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializerTest.java
@@ -53,6 +53,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -413,9 +414,8 @@ class SessionSerializerTest {
         verify(connector).markSerializationStarted(clusterSID, timeToLive);
 
         await().atMost(500, MILLISECONDS).untilTrue(serializationFailed);
-        assertThrows(RuntimeException.class,
-                () -> connector.sendSession(any()));
-        verify(connector).markSerializationFailed(eq(clusterSID), any());
+        verify(connector).markSerializationFailed(eq(clusterSID),
+                same(throwable));
     }
 
     @Test

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializerTest.java
@@ -88,7 +88,7 @@ class SessionSerializerTest {
 
         clusterSID = UUID.randomUUID().toString();
         httpSession = newHttpSession(clusterSID);
-        timeToLive = Duration.ofSeconds(5);
+        timeToLive = Duration.ofMinutes(35);
 
         vaadinService = new MockVaadinService();
         vaadinSession = vaadinService.newMockSession(httpSession);

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
@@ -101,18 +101,19 @@ public class HazelcastConnectorTest {
     }
 
     @Test
-    void markSerializationStarted_withZeroTTL_sessionLocked() {
-        connector.markSerializationStarted(clusterKey, Duration.ofSeconds(0L));
+    void markSerializationStarted_sessionLocked() {
+        connector.markSerializationStarted(clusterKey, Duration.ofMinutes(0));
 
-        verify(sessionMap).lock(eq(HazelcastConnector.getPendingKey(clusterKey)));
+        verify(sessionMap)
+                .lock(eq(HazelcastConnector.getPendingKey(clusterKey)));
     }
 
     @Test
-    void markSerializationStarted_withValidTTL_sessionLocked() {
-        connector.markSerializationStarted(clusterKey, Duration.ofSeconds(35));
+    void markSerializationStarted_expiration_sessionLockedWithTimeToLive() {
+        connector.markSerializationStarted(clusterKey, Duration.ofMinutes(30));
 
         verify(sessionMap).lock(
-                eq(HazelcastConnector.getPendingKey(clusterKey)), eq(35L),
+                eq(HazelcastConnector.getPendingKey(clusterKey)), eq(30L * 60),
                 eq(TimeUnit.SECONDS));
     }
 

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
@@ -118,6 +118,15 @@ public class HazelcastConnectorTest {
     }
 
     @Test
+    void markSerializationFailed_sessionNotLocked() {
+        Throwable error = new RuntimeException("error");
+        connector.markSerializationFailed(clusterKey, error);
+
+        verify(sessionMap)
+                .forceUnlock(eq(HazelcastConnector.getPendingKey(clusterKey)));
+    }
+
+    @Test
     void deleteSession_sessionNotLocked_sessionIsDeleted()
             throws InterruptedException {
         when(sessionMap.tryLock(

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
@@ -101,7 +101,14 @@ public class HazelcastConnectorTest {
     }
 
     @Test
-    void markSerializationStarted_sessionLocked() {
+    void markSerializationStarted_withZeroTTL_sessionLocked() {
+        connector.markSerializationStarted(clusterKey, Duration.ofSeconds(0L));
+
+        verify(sessionMap).lock(eq(HazelcastConnector.getPendingKey(clusterKey)));
+    }
+
+    @Test
+    void markSerializationStarted_withValidTTL_sessionLocked() {
         connector.markSerializationStarted(clusterKey, Duration.ofSeconds(35));
 
         verify(sessionMap).lock(

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
@@ -102,6 +102,14 @@ public class HazelcastConnectorTest {
 
     @Test
     void markSerializationStarted_sessionLocked() {
+        connector.markSerializationStarted(clusterKey);
+
+        verify(sessionMap)
+                .lock(eq(HazelcastConnector.getPendingKey(clusterKey)));
+    }
+
+    @Test
+    void markSerializationStarted_zeroExpiration_sessionLockedWithoutTimeToLive() {
         connector.markSerializationStarted(clusterKey, Duration.ofMinutes(0));
 
         verify(sessionMap)
@@ -109,7 +117,7 @@ public class HazelcastConnectorTest {
     }
 
     @Test
-    void markSerializationStarted_expiration_sessionLockedWithTimeToLive() {
+    void markSerializationStarted_validExpiration_sessionLockedWithTimeToLive() {
         connector.markSerializationStarted(clusterKey, Duration.ofMinutes(30));
 
         verify(sessionMap).lock(

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
@@ -101,14 +101,6 @@ public class HazelcastConnectorTest {
     }
 
     @Test
-    void markSerializationStarted_sessionLocked() {
-        connector.markSerializationStarted(clusterKey);
-
-        verify(sessionMap)
-                .lock(eq(HazelcastConnector.getPendingKey(clusterKey)));
-    }
-
-    @Test
     void markSerializationStarted_zeroExpiration_sessionLockedWithoutTimeToLive() {
         connector.markSerializationStarted(clusterKey, Duration.ofMinutes(0));
 

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
@@ -102,10 +102,10 @@ public class HazelcastConnectorTest {
 
     @Test
     void markSerializationStarted_sessionLocked() {
-        connector.markSerializationStarted(clusterKey, Duration.ofSeconds(5));
+        connector.markSerializationStarted(clusterKey, Duration.ofSeconds(35));
 
         verify(sessionMap).lock(
-                eq(HazelcastConnector.getPendingKey(clusterKey)), eq(5L),
+                eq(HazelcastConnector.getPendingKey(clusterKey)), eq(35L),
                 eq(TimeUnit.SECONDS));
     }
 

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
@@ -102,10 +102,11 @@ public class HazelcastConnectorTest {
 
     @Test
     void markSerializationStarted_sessionLocked() {
-        connector.markSerializationStarted(clusterKey);
+        connector.markSerializationStarted(clusterKey, Duration.ofSeconds(5));
 
-        verify(sessionMap)
-                .lock(eq(HazelcastConnector.getPendingKey(clusterKey)));
+        verify(sessionMap).lock(
+                eq(HazelcastConnector.getPendingKey(clusterKey)), eq(5L),
+                eq(TimeUnit.SECONDS));
     }
 
     @Test

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnectorTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnectorTest.java
@@ -91,7 +91,7 @@ public class RedisConnectorTest {
 
     @Test
     void markSerializationStarted_sessionLocked() {
-        Duration timeToLive = Duration.ofMinutes(5);
+        Duration timeToLive = Duration.ofMinutes(35);
         connector.markSerializationStarted(clusterKey, timeToLive);
 
         verify(connection.stringCommands()).set(

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnectorTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnectorTest.java
@@ -90,14 +90,6 @@ public class RedisConnectorTest {
     }
 
     @Test
-    void markSerializationStarted_sessionLocked() {
-        connector.markSerializationStarted(clusterKey);
-
-        verify(connection).set(aryEq(RedisConnector.getPendingKey(clusterKey)),
-                any());
-    }
-
-    @Test
     void markSerializationStarted_zeroExpiration_sessionLockedWithoutTimeToLive() {
         Duration timeToLive = Duration.ofMinutes(0);
         connector.markSerializationStarted(clusterKey, timeToLive);

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnectorTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnectorTest.java
@@ -91,6 +91,14 @@ public class RedisConnectorTest {
 
     @Test
     void markSerializationStarted_sessionLocked() {
+        connector.markSerializationStarted(clusterKey);
+
+        verify(connection).set(aryEq(RedisConnector.getPendingKey(clusterKey)),
+                any());
+    }
+
+    @Test
+    void markSerializationStarted_zeroExpiration_sessionLockedWithoutTimeToLive() {
         Duration timeToLive = Duration.ofMinutes(0);
         connector.markSerializationStarted(clusterKey, timeToLive);
 
@@ -99,7 +107,7 @@ public class RedisConnectorTest {
     }
 
     @Test
-    void markSerializationStarted_expiration_sessionLockedWithTimeToLive() {
+    void markSerializationStarted_validExpiration_sessionLockedWithTimeToLive() {
         Duration timeToLive = Duration.ofMinutes(30);
         connector.markSerializationStarted(clusterKey, timeToLive);
 

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnectorTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnectorTest.java
@@ -91,7 +91,16 @@ public class RedisConnectorTest {
 
     @Test
     void markSerializationStarted_sessionLocked() {
-        Duration timeToLive = Duration.ofMinutes(35);
+        Duration timeToLive = Duration.ofMinutes(0);
+        connector.markSerializationStarted(clusterKey, timeToLive);
+
+        verify(connection.stringCommands())
+                .set(aryEq(RedisConnector.getPendingKey(clusterKey)), any());
+    }
+
+    @Test
+    void markSerializationStarted_expiration_sessionLockedWithTimeToLive() {
+        Duration timeToLive = Duration.ofMinutes(30);
         connector.markSerializationStarted(clusterKey, timeToLive);
 
         verify(connection.stringCommands()).set(

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnectorTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/RedisConnectorTest.java
@@ -109,6 +109,15 @@ public class RedisConnectorTest {
     }
 
     @Test
+    void markSerializationFailed_sessionNotLocked() {
+        Throwable error = new RuntimeException("error");
+        connector.markSerializationFailed(clusterKey, error);
+
+        verify(connection.keyCommands())
+                .del(aryEq(RedisConnector.getPendingKey(clusterKey)));
+    }
+
+    @Test
     void deleteSession_sessionNotLocked_sessionIsDeleted() {
         when(connection.keyCommands().exists(any(byte[].class)))
                 .thenReturn(false);


### PR DESCRIPTION
The pending session keys should be removed if there is an error during the serialization. If some error happens during the pending session keys removal (like error while connecting to the backend caches or key deletion error), the TTL for the pending session keys will make sure that those are still removed.

- Marks the serialization failed and deletes/unlocks the pending sessions keys in the Redis/Hazelcast caches when the serialization fails with error before it could be marked as completed
- Adds TTL for the pending session keys when the serialization is marked as started in Redis and Hazelcast connectors. The TTL duration for the pending session keys is set to be the same as for the final session keys
- `RedisConnection` has some deprecated methods (`set()`, `del()`, etc.), those are replaced to be used with `RedisStringCommands.stringCommands()` `RedisKeyCommands.keyCommands()`

Closes #189 