### PR TITLE
Add a name element to the pom.xml files

### DIFF
--- a/kubernetes-kit-demo/pom.xml
+++ b/kubernetes-kit-demo/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>kubernetes-kit-demo</artifactId>
+    <name>Kubernetes Kit Demo</name>
 
     <properties>
         <maven.source.skip>true</maven.source.skip>

--- a/kubernetes-kit-starter/pom.xml
+++ b/kubernetes-kit-starter/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>kubernetes-kit-starter</artifactId>
+    <name>Kubernetes Kit Starter</name>
 
     <properties>
         <cvdl.name>vaadin-kubernetes-kit</cvdl.name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <artifactId>kubernetes-kit</artifactId>
     <version>2.4-SNAPSHOT</version>
     <packaging>pom</packaging>
+    <name>Kubernetes Kit</name>
 
     <licenses>
         <license>


### PR DESCRIPTION
Adding the name element to the `pom.xml` files in the project should fix the release build of the Kit. This is required because of the new Maven publish method.