### PR TITLE
fix: make LicenseCheckerServiceInitListener no-args constructor public

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/LicenseCheckerServiceInitListener.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/LicenseCheckerServiceInitListener.java
@@ -19,7 +19,11 @@ import com.vaadin.flow.server.startup.BaseLicenseCheckerServiceInitListener;
 public class LicenseCheckerServiceInitListener
         extends BaseLicenseCheckerServiceInitListener {
 
-    protected LicenseCheckerServiceInitListener() {
+    /**
+     * Initializes a license checking mechanism for Kubernetes Kit using its
+     * product name and current version.
+     */
+    public LicenseCheckerServiceInitListener() {
         super(ProductUtils.PRODUCT_NAME, ProductUtils.getVersion());
     }
 }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Prevents Spring DI errors like

```
java.util.ServiceConfigurationError: com.vaadin.flow.server.VaadinServiceInitListener: com.vaadin.kubernetes.starter.LicenseCheckerServiceInitListener Unable to get public no-arg constructor
Caused by: java.lang.NoSuchMethodException: com.vaadin.kubernetes.starter.LicenseCheckerServiceInitListener.<init>()
        at java.base/java.lang.Class.getConstructor0(Class.java:3761) ~[na:na]
```

because no public no-args constructor found.
