### PR TITLE
Make optimistic serialization timeout configurable

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/SerializationProperties.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/SerializationProperties.java
@@ -33,9 +33,9 @@ public class SerializationProperties {
 
     public static final int DEFAULT_OPTIMISTIC_SERIALIZATION_TIMEOUT_MS = 30000;
 
-    private int serializationTimeout = DEFAULT_SERIALIZATION_TIMEOUT_MS;
+    private int timeout = DEFAULT_SERIALIZATION_TIMEOUT_MS;
 
-    private int optimisticSerializationTimeout = DEFAULT_OPTIMISTIC_SERIALIZATION_TIMEOUT_MS;
+    private int optimisticTimeout = DEFAULT_OPTIMISTIC_SERIALIZATION_TIMEOUT_MS;
 
     @NestedConfigurationProperty
     private final TransientsProperties transients = new TransientsProperties();
@@ -47,52 +47,53 @@ public class SerializationProperties {
      * @return the timeout in milliseconds to wait for the serialization to be
      *         completed, defaults to 30000 ms
      */
-    public int getSerializationTimeout() {
-        return serializationTimeout;
+    public int getTimeout() {
+        return timeout;
     }
 
     /**
      * Sets the timeout in milliseconds to wait for the serialization to be
      * completed.
      *
-     * @param serializationTimeout
+     * @param timeout
      *            the timeout in milliseconds to wait for the serialization to
      *            be completed, defaults to 30000 ms
      */
-    public void setSerializationTimeout(int serializationTimeout) {
-        this.serializationTimeout = serializationTimeout;
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
     }
 
     /**
      * Gets the timeout in milliseconds to wait for the optimistic serialization
      * to be completed.
      * <p>
-     * 0 or negative value means that the optimistic serialization is skipped
+     * 0 or negative value means that the optimistic serialization is disabled
      * and only the pessimistic serialization is performed. Pessimistic
      * serialization locks the Vaadin session during the serialization process.
+     * Disabling the optimistic serialization may affect the UI performance.
      *
      * @return the timeout in milliseconds to wait for the optimistic
      *         serialization to be completed, defaults to 30000 ms
      */
-    public int getOptimisticSerializationTimeout() {
-        return optimisticSerializationTimeout;
+    public int getOptimisticTimeout() {
+        return optimisticTimeout;
     }
 
     /**
      * Sets the timeout in milliseconds to wait for the optimistic serialization
      * to be completed.
      * <p>
-     * 0 or negative value means that the optimistic serialization is skipped
+     * 0 or negative value means that the optimistic serialization is disabled
      * and only the pessimistic serialization is performed. Pessimistic
      * serialization locks the Vaadin session during the serialization process.
+     * Disabling the optimistic serialization may affect the UI performance.
      *
-     * @param optimisticSerializationTimeout
+     * @param optimisticTimeout
      *            the timeout in milliseconds to wait for the optimistic
      *            serialization to be completed, defaults to 30000 ms
      */
-    public void setOptimisticSerializationTimeout(
-            int optimisticSerializationTimeout) {
-        this.optimisticSerializationTimeout = optimisticSerializationTimeout;
+    public void setOptimisticTimeout(int optimisticTimeout) {
+        this.optimisticTimeout = optimisticTimeout;
     }
 
     /**

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
@@ -322,12 +322,11 @@ public class SessionSerializer
         boolean unrecoverableError = false;
         String clusterKey = getClusterKey(attributes);
         try {
-            if (serializationProperties
-                    .getOptimisticSerializationTimeout() > 0) {
+            if (serializationProperties.getOptimisticTimeout() > 0) {
                 checkUnserializableWrappers(attributes);
                 long start = System.currentTimeMillis();
-                long timeout = start + serializationProperties
-                        .getOptimisticSerializationTimeout();
+                long timeout = start
+                        + serializationProperties.getOptimisticTimeout();
                 getLogger().debug(
                         "Optimistic serialization of session {} with distributed key {} started",
                         sessionId, clusterKey);

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
@@ -300,8 +300,8 @@ public class SerializationDebugRequestHandler
 
     private int getSerializationTimeout(SerializationProperties properties) {
         int timeout = DEFAULT_SERIALIZATION_TIMEOUT_MS;
-        if (properties != null && properties.getSerializationTimeout() > 0) {
-            timeout = properties.getSerializationTimeout();
+        if (properties != null && properties.getTimeout() > 0) {
+            timeout = properties.getTimeout();
         } else {
             String timeoutStr = System
                     .getProperty(SERIALIZATION_TIMEOUT_PROPERTY);

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializerTest.java
@@ -219,7 +219,7 @@ class SessionSerializerTest {
     @Test
     void serialize_optimisticTimeoutZeroOrNegative_immediatelySwitchToPessimisticLocking() {
         // Set optimistic timeout to zero: should skip optimistic path entirely
-        serializationProperties.setOptimisticSerializationTimeout(0);
+        serializationProperties.setOptimisticTimeout(0);
 
         AtomicBoolean serializationStarted = new AtomicBoolean();
         doAnswer(i -> serializationStarted.getAndSet(true)).when(connector)
@@ -236,7 +236,8 @@ class SessionSerializerTest {
         await().during(100, MILLISECONDS).untilTrue(serializationStarted);
         verify(connector).markSerializationStarted(clusterSID, timeToLive);
 
-        // Since optimistic timeout is zero, do not wait; immediately allow pessimistic to proceed
+        // Since optimistic timeout is zero, do not wait; immediately allow
+        // pessimistic to proceed
         vaadinSession.unlock();
         vaadinSession.setLockTimestamps(30, 40);
 
@@ -244,7 +245,7 @@ class SessionSerializerTest {
         verify(connector).sendSession(notNull());
 
         // Now test with a negative timeout value as well
-        serializationProperties.setOptimisticSerializationTimeout(-1);
+        serializationProperties.setOptimisticTimeout(-1);
         serializationStarted.set(false);
         serializationCompleted.set(false);
 
@@ -254,7 +255,8 @@ class SessionSerializerTest {
 
         serializer.serialize(httpSession);
         await().during(100, MILLISECONDS).untilTrue(serializationStarted);
-        verify(connector, times(2)).markSerializationStarted(clusterSID, timeToLive);
+        verify(connector, times(2)).markSerializationStarted(clusterSID,
+                timeToLive);
 
         vaadinSession.unlock();
         vaadinSession.setLockTimestamps(50, 60);

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandlerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandlerTest.java
@@ -70,7 +70,7 @@ class SerializationDebugRequestHandlerTest {
     @BeforeEach
     void setUp() {
         SerializationProperties serializationProperties = new SerializationProperties();
-        serializationProperties.setSerializationTimeout(30000);
+        serializationProperties.setTimeout(30000);
         handler = new SerializationDebugRequestHandler(serializationProperties);
         httpSession = new MockHttpSession();
         VaadinService vaadinService = mock(VaadinService.class);
@@ -302,7 +302,7 @@ class SerializationDebugRequestHandlerTest {
     @Test
     void handleRequest_serializationTimeout_timeoutReported() {
         SerializationProperties properties = new SerializationProperties();
-        properties.setSerializationTimeout(100);
+        properties.setTimeout(100);
         handler = new SerializationDebugRequestHandler(properties);
 
         httpSession.setAttribute("OBJ1", new SlowSerialization());


### PR DESCRIPTION
Makes optimistic serialization timeout configurable in milliseconds. The default value is 30 seconds. If set to 0 or negative value the optimistic serialization is skipped and the pessimistic serialization is always used.