### PR TITLE
cp: Make optimistic serialization timeout configurable (#206)

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
@@ -80,16 +80,17 @@ public class KubernetesKitConfiguration {
         private static final Predicate<Class<?>> TRANSIENT_INJECTABLE_VAADIN_EXCLUSIONS = type -> !type
                 .getPackageName().startsWith("com.vaadin.flow.internal");
 
-        final KubernetesKitProperties properties;
+        final KubernetesKitProperties kubernetesKitProperties;
 
         public VaadinReplicatedSessionConfiguration(
-                KubernetesKitProperties properties) {
-            this.properties = properties;
+                KubernetesKitProperties kubernetesKitProperties) {
+            this.kubernetesKitProperties = kubernetesKitProperties;
         }
 
         SessionTrackerFilter sessionTrackerFilter(
                 SessionSerializer sessionSerializer) {
-            return new SessionTrackerFilter(sessionSerializer, properties);
+            return new SessionTrackerFilter(sessionSerializer,
+                    kubernetesKitProperties);
         }
 
         SessionListener sessionListener(BackendConnector backendConnector,
@@ -114,7 +115,7 @@ public class KubernetesKitConfiguration {
         @Bean
         @ConditionalOnMissingBean
         SessionExpirationPolicy sessionExpirationPolicy() {
-            Duration duration = properties
+            Duration duration = kubernetesKitProperties
                     .getBackendSessionExpirationTolerance();
             if (duration != null) {
                 return sessionTimeout -> duration.plus(sessionTimeout,
@@ -141,11 +142,12 @@ public class KubernetesKitConfiguration {
                 SessionSerializationCallback sessionSerializationCallback,
                 SessionExpirationPolicy sessionExpirationPolicy,
                 @Autowired(required = false) @Qualifier(TRANSIENT_INJECTABLE_FILTER) Predicate<Class<?>> injectablesFilter,
-                SerializationStreamFactory serializationStreamFactory) {
+                SerializationStreamFactory serializationStreamFactory,
+                SerializationProperties serializationProperties) {
             SessionSerializer sessionSerializer = new SessionSerializer(
                     backendConnector, transientInjector,
                     sessionExpirationPolicy, sessionSerializationCallback,
-                    serializationStreamFactory);
+                    serializationStreamFactory, serializationProperties);
             if (injectablesFilter != null) {
                 sessionSerializer.setInjectableFilter(injectablesFilter);
             }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/SerializationProperties.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/SerializationProperties.java
@@ -31,7 +31,11 @@ public class SerializationProperties {
 
     public static final int DEFAULT_SERIALIZATION_TIMEOUT_MS = 30000;
 
+    public static final int DEFAULT_OPTIMISTIC_SERIALIZATION_TIMEOUT_MS = 30000;
+
     private int timeout = DEFAULT_SERIALIZATION_TIMEOUT_MS;
+
+    private int optimisticTimeout = DEFAULT_OPTIMISTIC_SERIALIZATION_TIMEOUT_MS;
 
     @NestedConfigurationProperty
     private final TransientsProperties transients = new TransientsProperties();
@@ -60,6 +64,39 @@ public class SerializationProperties {
     }
 
     /**
+     * Gets the timeout in milliseconds to wait for the optimistic serialization
+     * to be completed.
+     * <p>
+     * 0 or negative value means that the optimistic serialization is disabled
+     * and only the pessimistic serialization is performed. Pessimistic
+     * serialization locks the Vaadin session during the serialization process.
+     * Disabling the optimistic serialization may affect the UI performance.
+     *
+     * @return the timeout in milliseconds to wait for the optimistic
+     *         serialization to be completed, defaults to 30000 ms
+     */
+    public int getOptimisticTimeout() {
+        return optimisticTimeout;
+    }
+
+    /**
+     * Sets the timeout in milliseconds to wait for the optimistic serialization
+     * to be completed.
+     * <p>
+     * 0 or negative value means that the optimistic serialization is disabled
+     * and only the pessimistic serialization is performed. Pessimistic
+     * serialization locks the Vaadin session during the serialization process.
+     * Disabling the optimistic serialization may affect the UI performance.
+     *
+     * @param optimisticTimeout
+     *            the timeout in milliseconds to wait for the optimistic
+     *            serialization to be completed, defaults to 30000 ms
+     */
+    public void setOptimisticTimeout(int optimisticTimeout) {
+        this.optimisticTimeout = optimisticTimeout;
+    }
+
+    /**
      * Gets configuration for transient fields handling during serialization.
      *
      * @return configuration for transient fields handling.
@@ -73,20 +110,20 @@ public class SerializationProperties {
         private final Set<String> excludePackages = new HashSet<>();
 
         /**
-         * Gets a list of packages to consider during class inspection for
+         * Gets a set of packages to consider during class inspection for
          * injectable transient fields.
          *
-         * @return list of packages included in class inspection.
+         * @return set of packages included in class inspection.
          */
         public Set<String> getIncludePackages() {
             return includePackages;
         }
 
         /**
-         * Gets a list of packages to exclude from class inspection for
+         * Gets a set of packages to exclude from class inspection for
          * injectable transient fields.
          *
-         * @return list of packages excluded from class inspection.
+         * @return set of packages excluded from class inspection.
          */
         public Set<String> getExcludePackages() {
             return excludePackages;
@@ -95,10 +132,10 @@ public class SerializationProperties {
         /**
          * Gets a predicate that filters classes based on include/exclude
          * packages configuration.
-         *
+         * <p>
          * An empty inclusion list means all classes are included. Exclusion
          * rules have higher priority over inclusion rules.
-         *
+         * <p>
          * If no inclusion nor exclusion rules are configured all class are
          * eligible for inspection.
          *

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
@@ -45,6 +45,7 @@ import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.WrappedHttpSession;
 import com.vaadin.flow.server.WrappedSession;
 import com.vaadin.kubernetes.starter.ProductUtils;
+import com.vaadin.kubernetes.starter.SerializationProperties;
 import com.vaadin.kubernetes.starter.sessiontracker.backend.BackendConnector;
 import com.vaadin.kubernetes.starter.sessiontracker.backend.SessionExpirationPolicy;
 import com.vaadin.kubernetes.starter.sessiontracker.backend.SessionInfo;
@@ -112,8 +113,6 @@ public class SessionSerializer
         ProductUtils.markAsUsed(SessionSerializer.class.getSimpleName());
     }
 
-    private static final long OPTIMISTIC_SERIALIZATION_TIMEOUT_MS = 30000;
-
     private final ExecutorService executorService = Executors
             .newFixedThreadPool(4, new SerializationThreadFactory());
 
@@ -124,13 +123,13 @@ public class SessionSerializer
     // (sessionId, clusterKey) -> TransientHandler
     private final BiFunction<String, String, TransientHandler> handlerProvider;
 
-    private final long optimisticSerializationTimeoutMs;
-
     private final SessionSerializationCallback sessionSerializationCallback;
 
     private final SessionExpirationPolicy sessionExpirationPolicy;
 
     private final SerializationStreamFactory serializationStreamFactory;
+
+    private final SerializationProperties serializationProperties;
 
     private Predicate<Class<?>> injectableFilter = type -> true;
 
@@ -145,15 +144,18 @@ public class SessionSerializer
      * @param sessionSerializationCallback
      *            callbacks for successful serialization and deserialization or
      *            when an error happens
+     * @param serializationProperties
+     *            the serialization properties
      */
     public SessionSerializer(BackendConnector backendConnector,
             TransientHandler transientHandler,
             SessionExpirationPolicy sessionExpirationPolicy,
             SessionSerializationCallback sessionSerializationCallback,
-            SerializationStreamFactory serializationStreamFactory) {
+            SerializationStreamFactory serializationStreamFactory,
+            SerializationProperties serializationProperties) {
         this(backendConnector, (sessionId, clusterKey) -> transientHandler,
                 sessionExpirationPolicy, sessionSerializationCallback,
-                serializationStreamFactory);
+                serializationStreamFactory, serializationProperties);
     }
 
     /**
@@ -180,33 +182,21 @@ public class SessionSerializer
      * @param sessionSerializationCallback
      *            callbacks for successful serialization and deserialization or
      *            when an error happens
+     * @param serializationProperties
+     *            the serialization properties
      */
     public SessionSerializer(BackendConnector backendConnector,
             BiFunction<String, String, TransientHandler> transientHandlerProvider,
             SessionExpirationPolicy sessionExpirationPolicy,
             SessionSerializationCallback sessionSerializationCallback,
-            SerializationStreamFactory serializationStreamFactory) {
+            SerializationStreamFactory serializationStreamFactory,
+            SerializationProperties serializationProperties) {
         this.backendConnector = backendConnector;
         this.handlerProvider = transientHandlerProvider;
         this.sessionSerializationCallback = sessionSerializationCallback;
         this.sessionExpirationPolicy = sessionExpirationPolicy;
         this.serializationStreamFactory = serializationStreamFactory;
-        optimisticSerializationTimeoutMs = OPTIMISTIC_SERIALIZATION_TIMEOUT_MS;
-    }
-
-    // Visible for test
-    SessionSerializer(BackendConnector backendConnector,
-            TransientHandler transientHandler,
-            SessionExpirationPolicy sessionExpirationPolicy,
-            SessionSerializationCallback sessionSerializationCallback,
-            long optimisticSerializationTimeoutMs,
-            SerializationStreamFactory serializationStreamFactory) {
-        this.backendConnector = backendConnector;
-        this.optimisticSerializationTimeoutMs = optimisticSerializationTimeoutMs;
-        this.sessionSerializationCallback = sessionSerializationCallback;
-        this.sessionExpirationPolicy = sessionExpirationPolicy;
-        this.handlerProvider = (sessionId, clusterKey) -> transientHandler;
-        this.serializationStreamFactory = serializationStreamFactory;
+        this.serializationProperties = serializationProperties;
     }
 
     /**
@@ -332,22 +322,25 @@ public class SessionSerializer
         boolean unrecoverableError = false;
         String clusterKey = getClusterKey(attributes);
         try {
-            checkUnserializableWrappers(attributes);
-            long start = System.currentTimeMillis();
-            long timeout = start + optimisticSerializationTimeoutMs;
-            getLogger().debug(
-                    "Optimistic serialization of session {} with distributed key {} started",
-                    sessionId, clusterKey);
-            while (System.currentTimeMillis() < timeout) {
-                SessionInfo info = serializeOptimisticLocking(sessionId,
-                        timeToLive, attributes);
-                if (info != null) {
-                    pending.remove(sessionId); // Is this a race condition?
-                    getLogger().debug(
-                            "Optimistic serialization of session {} with distributed key {} completed",
-                            sessionId, clusterKey);
-                    whenSerialized.accept(info);
-                    return;
+            if (serializationProperties.getOptimisticTimeout() > 0) {
+                checkUnserializableWrappers(attributes);
+                long start = System.currentTimeMillis();
+                long timeout = start
+                        + serializationProperties.getOptimisticTimeout();
+                getLogger().debug(
+                        "Optimistic serialization of session {} with distributed key {} started",
+                        sessionId, clusterKey);
+                while (System.currentTimeMillis() < timeout) {
+                    SessionInfo info = serializeOptimisticLocking(sessionId,
+                            timeToLive, attributes);
+                    if (info != null) {
+                        pending.remove(sessionId); // Is this a race condition?
+                        getLogger().debug(
+                                "Optimistic serialization of session {} with distributed key {} completed",
+                                sessionId, clusterKey);
+                        whenSerialized.accept(info);
+                        return;
+                    }
                 }
             }
         } catch (PessimisticSerializationRequiredException e) {
@@ -385,8 +378,11 @@ public class SessionSerializer
 
     private SessionInfo serializePessimisticLocking(String sessionId,
             Duration timeToLive, Map<String, Object> attributes) {
-        long start = System.currentTimeMillis();
         String clusterKey = getClusterKey(attributes);
+        long start = System.currentTimeMillis();
+        getLogger().debug(
+                "Pessimistic serialization of session {} with distributed key {} started",
+                sessionId, clusterKey);
         Set<ReentrantLock> locks = getLocks(attributes);
         for (ReentrantLock lock : locks) {
             lock.lock();

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
@@ -107,7 +107,8 @@ public class SerializationDebugRequestHandler
         this.sessionSerializer = new SessionSerializer(debugBackendConnector,
                 debugBackendConnector, SessionExpirationPolicy.NEVER,
                 SessionSerializationCallback.DEFAULT,
-                new TransientInjectableObjectStreamFactory());
+                new TransientInjectableObjectStreamFactory(),
+                serializationProperties);
     }
 
     @Override


### PR DESCRIPTION
Makes optimistic serialization timeout configurable in milliseconds. The default value is 30 seconds. If set to 0 or negative value the optimistic serialization is skipped and the pessimistic serialization is always used.