### PR TITLE
cp: Stop session listener when session tracker filter is destroyed (#208)

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
@@ -60,7 +60,7 @@ import com.vaadin.kubernetes.starter.sessiontracker.serialization.debug.DebugMod
 import com.vaadin.kubernetes.starter.sessiontracker.serialization.debug.SerializationDebugRequestHandler;
 
 /**
- * This configuration bean is provided to auto-configure Vaadin apps to run in a
+ * This configuration bean is provided to autoconfigure Vaadin apps to run in a
  * clustered environment.
  */
 @AutoConfiguration
@@ -88,9 +88,9 @@ public class KubernetesKitConfiguration {
         }
 
         SessionTrackerFilter sessionTrackerFilter(
-                SessionSerializer sessionSerializer) {
+                SessionSerializer sessionSerializer, Runnable destroyCallback) {
             return new SessionTrackerFilter(sessionSerializer,
-                    kubernetesKitProperties);
+                    kubernetesKitProperties, destroyCallback);
         }
 
         SessionListener sessionListener(BackendConnector backendConnector,
@@ -191,7 +191,8 @@ public class KubernetesKitConfiguration {
             pushSessionTracker.setActiveSessionChecker(
                     sessionListener.activeSessionChecker());
             FilterRegistrationBean<SessionTrackerFilter> registration = new FilterRegistrationBean<>(
-                    sessionTrackerFilter(sessionSerializer)) {
+                    sessionTrackerFilter(sessionSerializer,
+                            sessionListener::stop)) {
                 @Override
                 protected FilterRegistration.Dynamic addRegistration(
                         String description, ServletContext servletContext) {

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionListenerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionListenerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class SessionListenerTest {
+
     @AfterEach
     void cleanUp() {
         CurrentKey.clear();
@@ -148,6 +149,22 @@ public class SessionListenerTest {
         Assertions.assertFalse(checker.test(sessionEvent.getSession().getId()),
                 "HTTP Session should not be active");
 
+    }
+
+    @Test
+    void sessionListenerStopped_sessionNotCreatedOrDestroyed() {
+        BackendConnector backendConnector = mock(BackendConnector.class);
+        SessionSerializer sessionSerializer = mock(SessionSerializer.class);
+        HttpSessionEvent sessionEvent = createSessionEvent();
+        SessionListener listener = new SessionListener(backendConnector,
+                sessionSerializer);
+        listener.stop();
+
+        listener.sessionCreated(sessionEvent);
+        verify(sessionEvent, never()).getSession();
+
+        listener.sessionDestroyed(sessionEvent);
+        verify(sessionEvent, never()).getSession();
     }
 
     private static HttpSessionEvent createSessionEvent() {


### PR DESCRIPTION
- Added a destroy callback, that is run when the session tracker filter is destroyed, that stops the session listener and prevents processing any further events
- Added exception handling when PushSendListener instances are not available during the application shutdown
