### PR TITLE
fix: Catch Throwable (#227) (CP: 2.5)

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
@@ -523,7 +523,7 @@ public class SessionSerializer
                                 .append(ui.getInternals().getServerSyncId())
                                 .append("]");
                     }
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     // getting UIs may fail in development mode due to null lock
                     // (deserialization) or session not locked (serialization)
                     // ignoring for now since it is just a log


### PR DESCRIPTION
When session is not locked AssertionError is thrown, it is not Exception, but Throwable. Based on the comment intention is to catch this, so thus changing type accordingly.