### PR TITLE
fix: prevent creation of multiple HTTP sessions for a single cluster key (#223) (CP: 2.5)

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
@@ -88,9 +88,10 @@ public class KubernetesKitConfiguration {
         }
 
         SessionTrackerFilter sessionTrackerFilter(
-                SessionSerializer sessionSerializer, Runnable destroyCallback) {
+                SessionSerializer sessionSerializer,
+                SessionListener sessionListener) {
             return new SessionTrackerFilter(sessionSerializer,
-                    kubernetesKitProperties, destroyCallback);
+                    kubernetesKitProperties, sessionListener);
         }
 
         SessionListener sessionListener(BackendConnector backendConnector,
@@ -192,7 +193,8 @@ public class KubernetesKitConfiguration {
                     sessionListener.activeSessionChecker());
             FilterRegistrationBean<SessionTrackerFilter> registration = new FilterRegistrationBean<>(
                     sessionTrackerFilter(sessionSerializer,
-                            sessionListener::stop)) {
+                            // sessionListener::stop)) {
+                            sessionListener)) {
                 @Override
                 protected FilterRegistration.Dynamic addRegistration(
                         String description, ServletContext servletContext) {

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionListener.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionListener.java
@@ -9,10 +9,18 @@
  */
 package com.vaadin.kubernetes.starter.sessiontracker;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSessionAttributeListener;
+import jakarta.servlet.http.HttpSessionBindingEvent;
 import jakarta.servlet.http.HttpSessionEvent;
+import jakarta.servlet.http.HttpSessionIdListener;
 import jakarta.servlet.http.HttpSessionListener;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
@@ -42,11 +50,14 @@ import com.vaadin.kubernetes.starter.sessiontracker.backend.SessionInfo;
  * @see BackendConnector
  * @see SessionSerializer
  */
-public class SessionListener implements HttpSessionListener {
+public class SessionListener implements HttpSessionListener,
+        HttpSessionIdListener, HttpSessionAttributeListener {
 
     private final BackendConnector sessionBackendConnector;
     private final SessionSerializer sessionSerializer;
-    private final Set<String> activeSessions = ConcurrentHashMap.newKeySet();
+    // sessionID to clusterKey mapping
+    private final Map<String, String> activeSessions = new ConcurrentHashMap<>();
+    private final Map<String, SessionCreationRequest> sessionCreationRequestMap = new ConcurrentHashMap<>();
     private boolean stopped = false;
 
     /**
@@ -72,9 +83,9 @@ public class SessionListener implements HttpSessionListener {
         }
         HttpSession session = se.getSession();
         getLogger().debug("Session with id {} created", session.getId());
-        activeSessions.add(session.getId());
         String clusterKey = CurrentKey.get();
         if (clusterKey != null) {
+            activeSessions.put(session.getId(), clusterKey);
             SessionInfo sessionInfo = sessionBackendConnector
                     .getSession(clusterKey);
             if (sessionInfo != null) {
@@ -91,6 +102,11 @@ public class SessionListener implements HttpSessionListener {
                             clusterKey, session.getId(), e);
                 }
             }
+            sessionCreationRequestMap.put(clusterKey,
+                    new SessionCreationRequest(session.getId(),
+                            new HashSet<>()));
+        } else {
+            activeSessions.put(session.getId(), "");
         }
     }
 
@@ -101,9 +117,13 @@ public class SessionListener implements HttpSessionListener {
         }
         HttpSession session = se.getSession();
         String sessionId = session.getId();
-        activeSessions.remove(sessionId);
+        String associatedClusterKey = activeSessions.remove(sessionId);
+        if (associatedClusterKey != null) {
+            sessionCreationRequestMap.remove(associatedClusterKey);
+        }
         getLogger().debug("Session with id {} destroyed", sessionId);
         SessionTrackerCookie.getFromSession(session).ifPresent(clusterKey -> {
+            sessionCreationRequestMap.remove(clusterKey);
             getLogger().debug(
                     "Deleting data with key {} from distributed storage associated to session {}",
                     clusterKey, sessionId);
@@ -120,6 +140,117 @@ public class SessionListener implements HttpSessionListener {
         });
     }
 
+    @Override
+    public void sessionIdChanged(HttpSessionEvent event, String oldSessionId) {
+        String newSessionId = event.getSession().getId();
+        sessionCreationRequestMap.replaceAll((clusterKey, current) -> {
+            if (oldSessionId.equals(current.sessionId())) {
+                return new SessionCreationRequest(newSessionId,
+                        current.requestedSessionId());
+            }
+            return current;
+        });
+        String clusterKey = activeSessions.remove(oldSessionId);
+        activeSessions.put(newSessionId, clusterKey);
+    }
+
+    @Override
+    public void attributeAdded(HttpSessionBindingEvent event) {
+        updateClusterKeyToSessionAssociation(event);
+    }
+
+    @Override
+    public void attributeReplaced(HttpSessionBindingEvent event) {
+        updateClusterKeyToSessionAssociation(event);
+    }
+
+    private void updateClusterKeyToSessionAssociation(
+            HttpSessionBindingEvent event) {
+        if (CurrentKey.COOKIE_NAME.equals(event.getName())) {
+            String clusterKey = (String) event.getValue();
+            String sessionId = event.getSession().getId();
+            getLogger().debug("Associating cluster key {} to session {}",
+                    clusterKey, sessionId);
+            updateOrCreateSessionCreationRequest(clusterKey, sessionId);
+        }
+    }
+
+    private SessionCreationRequest updateOrCreateSessionCreationRequest(
+            String clusterKey, String sessionId) {
+        return sessionCreationRequestMap.compute(clusterKey,
+                (unused, current) -> {
+                    if (current == null) {
+                        return new SessionCreationRequest(sessionId,
+                                new HashSet<>());
+                    } else {
+                        return new SessionCreationRequest(sessionId,
+                                current.requestedSessionId());
+                    }
+                });
+    }
+
+    /**
+     * Finds an existing session associated with the provided cluster key and
+     * request. If a session corresponding to the provided requested session ID
+     * is found in the session creation request map, its session ID will be
+     * returned.
+     *
+     * @param clusterKey
+     *            the key identifying the session's associated cluster, must not
+     *            be null.
+     * @param request
+     *            the {@code HttpServletRequest} from which the requested
+     *            session ID will be obtained, must not be null.
+     * @return an {@code Optional} containing the session ID if an existing
+     *         session is found, or {@code Optional.empty()} if not.
+     */
+    Optional<String> findExistingSession(String clusterKey,
+            HttpServletRequest request) {
+        String requestedSessionId = request.getRequestedSessionId();
+        if (requestedSessionId == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(sessionCreationRequestMap.get(clusterKey))
+                .filter(req -> req.requestedSessionId()
+                        .contains(requestedSessionId))
+                .map(SessionCreationRequest::sessionId);
+    }
+
+    /**
+     * Associates the cluster key with the given session, tracking the original
+     * requested session identifier to detect concurrent requests that should
+     * wait for the completion of the current request to propagate the new
+     * session cookie to the client.
+     *
+     * @param clusterKey
+     *            The key identifying the session's associated cluster. Must not
+     *            be null.
+     * @param session
+     *            The HTTP session that has been created. Must not be null.
+     * @param request
+     *            The {@code HttpServletRequest} associated with the session.
+     *            Must not be null.
+     */
+    void sessionAssociated(String clusterKey, HttpSession session,
+            HttpServletRequest request) {
+        Objects.requireNonNull(clusterKey, "clusterKey must not be null");
+        Objects.requireNonNull(session, "session must not be null");
+        Objects.requireNonNull(request, "HTTP request must not be null");
+        String requestedSessionId = request.getRequestedSessionId();
+        String sessionId = session.getId();
+        if (!clusterKey.equals(activeSessions.get(sessionId))) {
+            throw new IllegalStateException("Session " + sessionId
+                    + " is not associated with cluster key " + clusterKey);
+        }
+        getLogger().debug(
+                "Session {} created for cluster key {} with requested session id {}",
+                sessionId, clusterKey, requestedSessionId);
+        if (sessionId != null) {
+            updateOrCreateSessionCreationRequest(clusterKey, sessionId)
+                    .requestedSessionId().add(requestedSessionId);
+        }
+    }
+
     /**
      * Gets a predicate that tests if the given identifier matches an active
      * HTTP session.
@@ -127,7 +258,7 @@ public class SessionListener implements HttpSessionListener {
      * @return a predicate to check if an HTTP session is active or not.
      */
     public Predicate<String> activeSessionChecker() {
-        return activeSessions::contains;
+        return activeSessions::containsKey;
     }
 
     /**
@@ -141,4 +272,9 @@ public class SessionListener implements HttpSessionListener {
     static Logger getLogger() {
         return LoggerFactory.getLogger(SessionListener.class);
     }
+
+    private record SessionCreationRequest(String sessionId,
+            Set<String> requestedSessionId) {
+    }
+
 }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTracker.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTracker.java
@@ -1,0 +1,29 @@
+package com.vaadin.kubernetes.starter.sessiontracker;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+import java.util.Optional;
+
+public interface SessionTracker {
+
+    void sessionCreated(String clusterKey, HttpSession session,
+            HttpServletRequest request);
+
+    /**
+     * Retrieves the session ID mapped to the given cluster key, if available.
+     * <p>
+     * It also
+     *
+     * @param clusterKey
+     *            the key used to identify a specific cluster in the session
+     *            context
+     * @return an {@code Optional} containing the session ID associated with the
+     *         given cluster key, or an empty {@code Optional} if no mapping
+     *         exists
+     */
+    Optional<String> mapSession(String clusterKey, HttpServletRequest request);
+
+    void stop();
+
+}

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/UnserializableComponentWrapper.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/UnserializableComponentWrapper.java
@@ -135,7 +135,9 @@ public class UnserializableComponentWrapper<S extends Serializable, T extends Co
                     .getInstances();
             CurrentInstance.set(UI.class, ui);
             CurrentInstance.set(VaadinSession.class, session);
-            Runnable cleaner = SessionUtil.injectLockIfNeeded(session);
+            Runnable lockCleaner = SessionUtil.injectLockIfNeeded(session);
+            Runnable serviceCleaner = SessionUtil
+                    .injectServiceIfNeeded(session);
             try {
                 getElement().removeAllChildren();
                 if (state != null) {
@@ -146,7 +148,8 @@ public class UnserializableComponentWrapper<S extends Serializable, T extends Co
             } finally {
                 CurrentInstance.clearAll();
                 CurrentInstance.restoreInstances(instances);
-                cleaner.run();
+                lockCleaner.run();
+                serviceCleaner.run();
             }
         });
     }

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerFilterTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerFilterTest.java
@@ -1,35 +1,51 @@
 package com.vaadin.kubernetes.starter.sessiontracker;
 
+import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSessionEvent;
 
 import java.io.IOException;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
 import org.springframework.mock.web.MockHttpSession;
 
 import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.kubernetes.starter.KubernetesKitProperties;
+import com.vaadin.kubernetes.starter.sessiontracker.backend.BackendConnector;
+import com.vaadin.kubernetes.starter.sessiontracker.backend.SessionInfo;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -38,9 +54,11 @@ import static org.mockito.Mockito.when;
 class SessionTrackerFilterTest {
 
     SessionSerializer serializer = mock(SessionSerializer.class);
-    Runnable destroyCallback = mock(Runnable.class);
+    BackendConnector backendConnector = Mockito.mock(BackendConnector.class);
+    SessionListener sessionListener = spy(
+            new SessionListener(backendConnector, serializer));
     SessionTrackerFilter filter = new SessionTrackerFilter(serializer,
-            new KubernetesKitProperties(), destroyCallback);
+            new KubernetesKitProperties(), sessionListener);
 
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);
@@ -52,6 +70,12 @@ class SessionTrackerFilterTest {
 
     @Captor
     private ArgumentCaptor<Consumer<Cookie>> cookieConsumerArgumentCaptor;
+
+    @BeforeEach
+    void mockBackendConnector() {
+        when(backendConnector.getSession(any()))
+                .thenReturn(new SessionInfo("TEST", new byte[0]));
+    }
 
     @Test
     void validHttpSession_UIDLRequest_sessionSerialized() throws Exception {
@@ -69,7 +93,7 @@ class SessionTrackerFilterTest {
     }
 
     @Test
-    void vaadinRequest_notUIDL_sessionSerialized() throws Exception {
+    void vaadinRequest_notUIDL_sessionNotSerialized() throws Exception {
         setupCookie();
         when(request.getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
                 .thenReturn(HandlerHelper.RequestType.INIT.getIdentifier());
@@ -84,8 +108,10 @@ class SessionTrackerFilterTest {
     }
 
     @Test
-    void nullHttpSession_notUIDLRequest_sessionSerialized() throws Exception {
+    void nonVaadinRequest_notUIDLRequest_sessionNotSerialized()
+            throws Exception {
         setupCookie();
+        setupHttpSession();
         when(request.isRequestedSessionIdValid()).thenReturn(true);
         filter.doFilter(request, response, filterChain);
         verifyNoInteractions(serializer);
@@ -112,7 +138,11 @@ class SessionTrackerFilterTest {
         MockHttpSession httpSession = new MockHttpSession();
         when(request.getSession(false)).thenReturn(null, httpSession);
         when(request.getSession(true)).thenReturn(httpSession);
-        when(request.isRequestedSessionIdValid()).thenReturn(true);
+        when(request.isRequestedSessionIdValid()).thenReturn(false);
+        when(request.getSession(true)).thenAnswer(i -> {
+            sessionListener.sessionCreated(new HttpSessionEvent(httpSession));
+            return httpSession;
+        });
         filter.doFilter(request, response, filterChain);
 
         assertThat(httpSession.getAttribute(CurrentKey.COOKIE_NAME))
@@ -160,9 +190,109 @@ class SessionTrackerFilterTest {
     }
 
     @Test
+    void notExistingSession_trackedCookiePresent_concurrentRequest_sessionInitialized()
+            throws Exception {
+        // Slow down deserialization to simulate concurrent requests
+        doAnswer(i -> {
+            Thread.sleep(1000);
+            return null;
+        }).when(serializer).deserialize(any(), any());
+
+        String invalidSessionId = UUID.randomUUID().toString();
+        var execution1 = createTestRequest(cookie, invalidSessionId);
+        var execution2 = createTestRequest(cookie, invalidSessionId);
+
+        CompletableFuture.allOf(
+                CompletableFuture.runAsync(() -> execution1.execute(filter)),
+                CompletableFuture.runAsync(() -> execution2.execute(filter)))
+                .join();
+
+        TestRequest sessionCreationExecution;
+        TestRequest waitingExecution;
+        if (execution1.session().get() != null) {
+            sessionCreationExecution = execution1;
+            waitingExecution = execution2;
+        } else {
+            sessionCreationExecution = execution2;
+            waitingExecution = execution1;
+        }
+
+        verify(sessionCreationExecution.chain).doFilter(
+                sessionCreationExecution.request(),
+                sessionCreationExecution.response());
+        verify(sessionCreationExecution.request).getSession(true);
+        assertThat(sessionCreationExecution.session()).doesNotHaveNullValue();
+        //verify(sessionCreationExecution.response, never())
+        //        .sendRedirect(anyString(), anyInt());
+        verify(sessionCreationExecution.response, never())
+                .setHeader(eq("Location"), anyString());
+        verify(sessionCreationExecution.response, never())
+                .setStatus(307);
+
+        //verify(waitingExecution.response).sendRedirect(anyString(), eq(307));
+        verify(waitingExecution.response)
+                .setHeader(eq("Location"), anyString());
+        verify(waitingExecution.response).setStatus(307);
+
+        verify(waitingExecution.request, never()).getSession(true);
+        verify(waitingExecution.chain, never()).doFilter(
+                waitingExecution.request(), waitingExecution.response());
+        assertThat(waitingExecution.session()).hasNullValue();
+
+        // Simulate the temporary redirect still have the old session cookie
+        var redirect = createTestRequest(cookie, invalidSessionId);
+        redirect.execute(filter);
+        verify(redirect.request, never()).getSession(true);
+        //verify(redirect.response).sendRedirect(anyString(), eq(307));
+        verify(redirect.response)
+                .setHeader(eq("Location"), anyString());
+        verify(redirect.response)
+                .setStatus(307);
+
+
+        verify(redirect.chain, never()).doFilter(waitingExecution.request(),
+                waitingExecution.response());
+        assertThat(redirect.session()).hasNullValue();
+
+        // Simulate the temporary redirect with the correct session cookie
+        redirect = createTestRequest(cookie,
+                sessionCreationExecution.session().get().getId());
+        redirect.execute(filter);
+        verify(redirect.request, never()).getSession(true);
+        verify(redirect.chain).doFilter(redirect.request(),
+                redirect.response());
+        assertThat(redirect.session())
+                .hasValue(sessionCreationExecution.session().get());
+
+        // Simulate a request from a browser that has the same cluster key but a
+        // different requested session id
+        // Should never happen unless the session cookie is manually altered on
+        // the browser
+        // In this case we allow creation of a new session to prevent infinite
+        // redirect loop
+        var requestWithDifferentSessionRequestedId = createTestRequest(cookie,
+                "aDifferentSessionId");
+        requestWithDifferentSessionRequestedId.execute(filter);
+        //verify(requestWithDifferentSessionRequestedId.response, never())
+        //        .sendRedirect(anyString(), anyInt());
+        verify(requestWithDifferentSessionRequestedId.response, never())
+                .setHeader(eq("Location"), anyString());
+        verify(requestWithDifferentSessionRequestedId.response, never())
+                .setStatus(307);
+        verify(requestWithDifferentSessionRequestedId.request).getSession(true);
+        verify(requestWithDifferentSessionRequestedId.chain).doFilter(
+                requestWithDifferentSessionRequestedId.request(),
+                requestWithDifferentSessionRequestedId.response());
+        assertThat(requestWithDifferentSessionRequestedId.session())
+                .doesNotHaveNullValue()
+                .isNotSameAs(sessionCreationExecution.session().get());
+
+    }
+
+    @Test
     void filterDestroyed_destroyCallback_run() {
         filter.destroy();
-        verify(destroyCallback).run();
+        verify(sessionListener).stop();
     }
 
     private MockHttpSession setupHttpSession() {
@@ -173,5 +303,69 @@ class SessionTrackerFilterTest {
 
     private void setupCookie() {
         when(request.getCookies()).thenReturn(new Cookie[] { cookie });
+    }
+
+    record TestRequest(HttpServletRequest request, HttpServletResponse response,
+            AtomicReference<HttpSession> session, String requestedSessionId,
+            FilterChain chain) {
+
+        void execute(Filter filter) {
+            try {
+                filter.doFilter(request, response, chain);
+            } catch (ServletException | IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        String currentSessionId() {
+            if (session.get() == null) {
+                return requestedSessionId;
+            }
+            return session.get().getId();
+        }
+
+    }
+
+    private final ConcurrentHashMap<String, HttpSession> sessionStore = new ConcurrentHashMap<>();
+
+    private TestRequest createTestRequest(Cookie cookie,
+            String requestedSessionId) {
+        // lenient mock because stub calls might be hit or not
+        HttpServletRequest request = mock(HttpServletRequest.class,
+                Mockito.withSettings().strictness(Strictness.LENIENT));
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        AtomicReference<HttpSession> createdSession = new AtomicReference<>();
+        TestRequest testRequest = new TestRequest(request, response,
+                createdSession, requestedSessionId, mock(FilterChain.class));
+
+        when(request.getSession(true)).thenAnswer(i -> {
+            String sid = testRequest.requestedSessionId();
+            var session = sessionStore.get(sid);
+            if (session != null) {
+                return session;
+            }
+            MockHttpSession httpSession = new MockHttpSession();
+            sessionStore.put(httpSession.getId(), httpSession);
+            sessionListener.sessionCreated(new HttpSessionEvent(httpSession));
+            testRequest.session().set(httpSession);
+            return httpSession;
+        });
+        when(request.getSession(false)).then(i -> {
+            HttpSession currentSession = testRequest.session().get();
+            if (currentSession != null) {
+                return currentSession;
+            }
+            HttpSession httpSession = sessionStore
+                    .get(testRequest.requestedSessionId());
+            testRequest.session().set(httpSession);
+            return httpSession;
+        });
+        when(request.getRequestedSessionId())
+                .then(i -> testRequest.requestedSessionId());
+        when(request.isRequestedSessionIdValid()).then(
+                i -> sessionStore.containsKey(testRequest.requestedSessionId));
+        when(request.getCookies()).thenReturn(new Cookie[] { cookie });
+
+        return testRequest;
     }
 }


### PR DESCRIPTION
* fix: prevent creation of multiple HTTP sessions for a single cluster key

* add test

* refactor test

* apply review suggestions
