### PR TITLE
Update testbench.version from alpha3 to beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <flow.version>25.0-SNAPSHOT</flow.version>
-        <testbench.version>10.0.0-alpha3</testbench.version>
+        <testbench.version>10.0.0-beta4</testbench.version>
         <spring.boot.version>4.0.0-RC2</spring.boot.version>
         <maven.jar.version>3.3.0</maven.jar.version>
         <maven.source.version>3.2.1</maven.source.version>


### PR DESCRIPTION
This pull request makes a minor update to the `pom.xml` file, upgrading the `testbench.version` from `10.0.0-alpha3` to `10.0.0-beta4`.