### PR TITLE
fix: reference redis autoconfiguration by name

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
@@ -65,7 +65,7 @@ import com.vaadin.kubernetes.starter.sessiontracker.serialization.debug.Serializ
  */
 @AutoConfiguration
 @ConditionalOnProperty(name = "auto-configure", prefix = KubernetesKitProperties.PREFIX, matchIfMissing = true)
-@AutoConfigureAfter(value = { SpringBootAutoConfiguration.class })
+@AutoConfigureAfter(SpringBootAutoConfiguration.class)
 @EnableConfigurationProperties({ KubernetesKitProperties.class,
         SerializationProperties.class })
 public class KubernetesKitConfiguration {
@@ -269,8 +269,7 @@ public class KubernetesKitConfiguration {
     }
 
     @AutoConfiguration
-    @ConditionalOnClass({ RedisConnectionFactory.class,
-            DataRedisAutoConfiguration.class })
+    @ConditionalOnClass(DataRedisAutoConfiguration.class)
     @AutoConfigureAfter(DataRedisAutoConfiguration.class)
     public static class RedisConfiguration {
         @Bean


### PR DESCRIPTION
Uses class name to reference  DataRedisAutoConfiguration in KubernetesKitConfiguration to prevent class not found exception at runtime.

Fixes #237