### PR TITLE
test: enable and fix tests (2.6)

### DIFF
--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/LicenseCheckerServiceInitListenerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/LicenseCheckerServiceInitListenerTest.java
@@ -9,6 +9,7 @@
  */
 package com.vaadin.kubernetes.starter;
 
+import com.vaadin.pro.licensechecker.Capability;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,8 @@ import com.vaadin.pro.licensechecker.LicenseChecker;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
@@ -61,8 +64,9 @@ class LicenseCheckerServiceInitListenerTest {
 
         // Verify the license is checked
         BuildType buildType = null;
-        licenseChecker.verify(() -> LicenseChecker
-                .checkLicense(ProductUtils.PRODUCT_NAME, version, buildType));
+        licenseChecker.verify(() -> LicenseChecker.checkLicense(
+                eq(ProductUtils.PRODUCT_NAME), eq(version),
+                argThat(cap -> cap.has(Capability.PRE_TRIAL)), eq(buildType)));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <maven.jar.version>3.3.0</maven.jar.version>
         <maven.source.version>3.2.1</maven.source.version>
         <maven.javadoc.version>3.4.1</maven.javadoc.version>
-        <maven.surefire.version>2.22.2</maven.surefire.version>
+        <maven.surefire.version>3.5.4</maven.surefire.version>
         <maven.formatter.version>2.20.0</maven.formatter.version>
     </properties>
 
@@ -99,7 +99,7 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>license-checker</artifactId>
-                <version>2.0.0</version>
+                <version>2.1.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Surefire version used by this branch prevented tests from being executed. This change bumps surefire to 3.5 and fixes a test to adapt it to changes in the license checker.
