### PR TITLE
fix: introduce a delay between optimistic serialization attempts

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/SerializationProperties.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/SerializationProperties.java
@@ -33,9 +33,13 @@ public class SerializationProperties {
 
     public static final int DEFAULT_OPTIMISTIC_SERIALIZATION_TIMEOUT_MS = 30000;
 
+    public static final int DEFAULT_OPTIMISTIC_SERIALIZATION_DELAY_MS = 10;
+
     private int timeout = DEFAULT_SERIALIZATION_TIMEOUT_MS;
 
     private int optimisticTimeout = DEFAULT_OPTIMISTIC_SERIALIZATION_TIMEOUT_MS;
+
+    private int optimisticDelay = DEFAULT_OPTIMISTIC_SERIALIZATION_DELAY_MS;
 
     @NestedConfigurationProperty
     private final TransientsProperties transients = new TransientsProperties();
@@ -94,6 +98,34 @@ public class SerializationProperties {
      */
     public void setOptimisticTimeout(int optimisticTimeout) {
         this.optimisticTimeout = optimisticTimeout;
+    }
+
+    /**
+     * Gets the delay in milliseconds to wait between optimistic serialization
+     * attempts.
+     * <p>
+     * A value of 0 or negative means no delay is applied between attempts.
+     * Note that disabling the delay may increase CPU usage significantly.
+     *
+     * @return the delay in milliseconds between optimistic serialization
+     *         attempts (default: 10)
+     */
+    public int getOptimisticDelay() {
+        return optimisticDelay;
+    }
+
+    /**
+     * Sets the delay in milliseconds to wait between optimistic serialization
+     * attempts.
+     * <p>
+     * A value of 0 or negative means no delay is applied between attempts.
+     * Note that disabling the delay may increase CPU usage significantly.
+     *
+     * @param delay the delay in milliseconds between optimistic serialization
+     *              attempts (default: 10)
+     */
+    public void setOptimisticDelay(int delay) {
+        this.optimisticDelay = delay;
     }
 
     /**

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializer.java
@@ -362,6 +362,7 @@ public class SessionSerializer implements
             if (!stopped.get()
                     && serializationProperties.getOptimisticTimeout() > 0) {
                 checkUnserializableWrappers(attributes);
+                long delay = serializationProperties.getOptimisticDelay();
                 long start = System.currentTimeMillis();
                 long timeout = start
                         + serializationProperties.getOptimisticTimeout();
@@ -382,6 +383,18 @@ public class SessionSerializer implements
                                 sessionId, clusterKey);
                         whenSerialized.accept(info);
                         return;
+                    }
+                    if (delay > 0) {
+                        try {
+                            // Introduce a small delay to reduce CPU usage
+                            Thread.sleep(delay);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            getLogger().debug("Optimistic serialization interrupted for session {} with distributed key {}",
+                                    sessionId, clusterKey);
+                            // Exit loop and fall through to pessimistic serialization
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Introduces a delay between optimistic serialization attempts to reduce CPU usage. The dealy is 10 milliseconds by default but can be configured by the developer in application.properties.
