### PR TITLE
fix: block incoming requests when application is shutting down (#244) (CP: 2.6)

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerFilter.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerFilter.java
@@ -95,14 +95,17 @@ public class SessionTrackerFilter extends HttpFilter {
     protected void doFilter(HttpServletRequest request,
             HttpServletResponse response, FilterChain chain)
             throws IOException, ServletException {
+
         String cookieName = properties.getClusterKeyCookieName();
 
         AtomicReference<Boolean> replayRequestRequired = new AtomicReference<>(
                 false);
 
-        SessionTrackerCookie.getValue(request, cookieName).ifPresent(key -> {
-            boolean sessionExists = request.getSession(false) != null;
-            if (!sessionExists) {
+        // prevent a session creation attempt on shutdown
+        var trackerCookie = SessionTrackerCookie.getValue(request, cookieName);
+        if (trackerCookie.isPresent() && sessionSerializer.isRunning()) {
+            var key = trackerCookie.get();
+            if (request.getSession(false) == null) {
                 createOrWaitForSession(request, key, replayRequestRequired);
             } else {
                 getLogger().debug(
@@ -110,21 +113,23 @@ public class SessionTrackerFilter extends HttpFilter {
                         key, request.getRequestURI());
                 pendingSessionCreation.remove(key);
             }
-        });
+        }
+
+        // Force redirect if the server is shutting down, to prevent potential
+        // modifications to the VaadinSession; the SessionSerializer status
+        // is read again because stop happens asynchronously
+        if (!sessionSerializer.isRunning()) {
+            forceRequestReply(request, response,
+                    "Redirecting current request session ID {} to {} because server is shutting down");
+            return;
+        }
 
         // If this is a waiting request, redirect to ensure it uses the new
-        // session ID
-        // The waiting thread only proceeds here after the first request has
-        // flushed its response
+        // session ID; the waiting thread only proceeds here after the first
+        // request has flushed its response
         if (Boolean.TRUE.equals(replayRequestRequired.get())) {
-            String redirectUrl = buildRedirectUrl(request);
-            getLogger().debug(
-                    "Redirecting current request session ID {} to {} to use the new session ID",
-                    request.getRequestedSessionId(), redirectUrl);
-            //response.sendRedirect(redirectUrl, 307);
-            response.setStatus(307);
-            response.setHeader("Location", redirectUrl);
-            response.flushBuffer();
+            forceRequestReply(request, response,
+                    "Redirecting current request session ID {} to {} to use the new session ID");
             return;
         }
 
@@ -164,6 +169,16 @@ public class SessionTrackerFilter extends HttpFilter {
         } finally {
             CurrentKey.clear();
         }
+    }
+
+    private void forceRequestReply(HttpServletRequest request,
+            HttpServletResponse response, String message) throws IOException {
+        String redirectUrl = buildRedirectUrl(request);
+        getLogger().debug(message, request.getRequestedSessionId(),
+                redirectUrl);
+        response.setStatus(307);
+        response.setHeader("Location", redirectUrl);
+        response.flushBuffer();
     }
 
     /**

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
@@ -114,7 +114,7 @@ public class SerializationDebugRequestHandler
     @Override
     public void onApplicationEvent(ContextClosedEvent event) {
         debugBackendConnector.shutdown();
-        sessionSerializer.onApplicationEvent(event);
+        sessionSerializer.stop();
     }
 
     @Override

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializerTest.java
@@ -393,8 +393,7 @@ class SessionSerializerTest {
         // Simulate stop asynchronously to prevent blocking the current thread
         AtomicBoolean stopCompleted = new AtomicBoolean();
         CompletableFuture
-                .runAsync(() -> serializer.onApplicationEvent(
-                        new ContextClosedEvent(mock(ApplicationContext.class))))
+                .runAsync(() -> serializer.stop())
                 .whenComplete((r, e) -> stopCompleted.set(e == null));
 
         await().until(() -> !serializer.isRunning());
@@ -448,8 +447,7 @@ class SessionSerializerTest {
         // Simulate stop asynchronously to prevent blocking the current thread
         AtomicBoolean stopCompleted = new AtomicBoolean();
         CompletableFuture
-                .runAsync(() -> serializer.onApplicationEvent(
-                        new ContextClosedEvent(mock(ApplicationContext.class))))
+                .runAsync(() -> serializer.stop())
                 .whenComplete((r, e) -> stopCompleted.set(e == null));
 
         // Expect serializer to switch to pessimistic locking almost immediately
@@ -487,8 +485,7 @@ class SessionSerializerTest {
         // Simulate stop asynchronously to prevent blocking the current thread
         AtomicBoolean stopCompleted = new AtomicBoolean();
         CompletableFuture
-                .runAsync(() -> serializer.onApplicationEvent(
-                        new ContextClosedEvent(mock(ApplicationContext.class))))
+                .runAsync(() -> serializer.stop())
                 .whenComplete((r, e) -> stopCompleted.set(e == null));
 
         await().until(() -> !serializer.isRunning());

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerFilterTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionTrackerFilterTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -37,7 +38,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -45,15 +45,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({ MockitoExtension.class })
 class SessionTrackerFilterTest {
 
     SessionSerializer serializer = mock(SessionSerializer.class);
+    AtomicBoolean serializerRunning = new AtomicBoolean(true);
     BackendConnector backendConnector = Mockito.mock(BackendConnector.class);
     SessionListener sessionListener = spy(
             new SessionListener(backendConnector, serializer));
@@ -72,9 +71,10 @@ class SessionTrackerFilterTest {
     private ArgumentCaptor<Consumer<Cookie>> cookieConsumerArgumentCaptor;
 
     @BeforeEach
-    void mockBackendConnector() {
+    void setupMocks() {
         when(backendConnector.getSession(any()))
                 .thenReturn(new SessionInfo("TEST", new byte[0]));
+        when(serializer.isRunning()).then(i -> serializerRunning.get());
     }
 
     @Test
@@ -101,7 +101,7 @@ class SessionTrackerFilterTest {
         MockHttpSession httpSession = setupHttpSession();
         filter.doFilter(request, response, filterChain);
 
-        verifyNoInteractions(serializer);
+        verify(serializer, never()).serialize(any(HttpSession.class));
         assertThat(httpSession.getAttribute(CurrentKey.COOKIE_NAME))
                 .isEqualTo(cookie.getValue());
         verify(filterChain).doFilter(request, response);
@@ -114,7 +114,7 @@ class SessionTrackerFilterTest {
         setupHttpSession();
         when(request.isRequestedSessionIdValid()).thenReturn(true);
         filter.doFilter(request, response, filterChain);
-        verifyNoInteractions(serializer);
+        verify(serializer, never()).serialize(any(HttpSession.class));
         verify(filterChain).doFilter(request, response);
     }
 
@@ -125,7 +125,7 @@ class SessionTrackerFilterTest {
         MockHttpSession httpSession = setupHttpSession();
         filter.doFilter(request, response, filterChain);
 
-        verifyNoInteractions(serializer);
+        verify(serializer, never()).serialize(any(HttpSession.class));
         assertThat(httpSession.getAttribute(CurrentKey.COOKIE_NAME))
                 .isEqualTo(cookie.getValue());
         verify(filterChain).doFilter(request, response);
@@ -160,7 +160,7 @@ class SessionTrackerFilterTest {
         MockHttpSession httpSession = setupHttpSession();
         filter.doFilter(request, response, filterChain);
 
-        verifyNoInteractions(serializer);
+        verify(serializer, never()).serialize(any(HttpSession.class));
         assertThat(httpSession.getAttribute(CurrentKey.COOKIE_NAME))
                 .isEqualTo(cookie.getValue());
         verify(filterChain).doFilter(request, response);
@@ -287,6 +287,25 @@ class SessionTrackerFilterTest {
                 .doesNotHaveNullValue()
                 .isNotSameAs(sessionCreationExecution.session().get());
 
+    }
+
+    @Test
+    void doFilter_sessionSerializerStopped_rejectIncomingRequests()
+            throws Exception {
+        setupCookie();
+        when(request.getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
+                .thenReturn(HandlerHelper.RequestType.UIDL.getIdentifier());
+        when(request.isRequestedSessionIdValid()).thenReturn(true);
+        MockHttpSession httpSession = setupHttpSession();
+        serializerRunning.set(false);
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(response).setStatus(307);
+        verify(response).setHeader(eq("Location"), anyString());
+        verify(response).flushBuffer();
+        verify(serializer, never()).serialize(httpSession);
+        verify(filterChain, never()).doFilter(request, response);
     }
 
     @Test


### PR DESCRIPTION
Updates SessionTrackerFilter to reject any incoming request if the application is shutting down. Shutdown state is read from SessionSerializer, that now implements SmartLifecycle interface in order to get notified early about the stop of the server. This way it could complete pending jobs before other services and beans (like the BackendConnector) receive the stop event.

Fixes #232
