### PR TITLE
fix: ensure backend connector remains available until last serialization completes (#253)

### DIFF
--- a/kubernetes-kit-demo/src/main/java/com/vaadin/kubernetes/demo/Application.java
+++ b/kubernetes-kit-demo/src/main/java/com/vaadin/kubernetes/demo/Application.java
@@ -1,5 +1,7 @@
 package com.vaadin.kubernetes.demo;
 
+import com.vaadin.kubernetes.starter.sessiontracker.SessionSerializationCallback;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -8,6 +10,8 @@ import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.Theme;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
+import org.springframework.context.annotation.Bean;
 
 /**
  * The entry point of the Spring Boot application.
@@ -28,4 +32,49 @@ public class Application implements AppShellConfigurator {
         SpringApplication.run(Application.class, args);
     }
 
+    /**
+     * A {@link SessionSerializationCallback} that simulates slow serialization
+     * to troubleshoot serialization/deserialization issues.
+     * <p>
+     * The bean is activated by the {@code vaadin.test.slow-serializer.enable}
+     * property. Serialization and deserialization delays are configurable via
+     * the {@code vaadin.test.slow-serializer.serialization-delay} and
+     * {@code vaadin.test.slow-serializer.deserialization-delay} properties,
+     * expressing the delay in milliseconds.
+     *
+     * @param serializationDelay
+     *            the amount of time to wait before completing the serialization
+     *            process.
+     * @param deserializationDelay
+     *            the amount of time to wait before completing the
+     *            deserialization process.
+     * @return a {@link SessionSerializationCallback} that simulates slow
+     *         serialization/deserialization.
+     */
+    @ConditionalOnBooleanProperty("vaadin.test.slow-serializer.enable")
+    @Bean
+    SessionSerializationCallback simulateSlowSerialization(
+            @Value("${vaadin.test.slow-serializer.serialization-delay:5000}") long serializationDelay,
+            @Value("${vaadin.test.slow-serializer.deserialization-delay:5000}") long deserializationDelay) {
+
+        return new SessionSerializationCallback() {
+            @Override
+            public void onSerializationSuccess() {
+                sleep(serializationDelay);
+            }
+
+            @Override
+            public void onDeserializationSuccess() {
+                sleep(deserializationDelay);
+            }
+
+            private void sleep(long millis) {
+                try {
+                    Thread.sleep(millis);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        };
+    }
 }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
@@ -303,6 +303,9 @@ public class KubernetesKitConfiguration {
             final var config = new Config();
 
             configure(config);
+            // Make sure Hazelcast shutdown hook is disabled so that the instance
+            // will be stopped after SessionSerializer saved the latest pending state
+            config.setProperty("hazelcast.shutdownhook.enabled", "false");
             configureKubernetes(config);
 
             return createHazelcastInstance(config);

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/backend/HazelcastConnectorTest.java
@@ -4,8 +4,11 @@ import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
+import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.spi.properties.HazelcastProperty;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,7 +36,12 @@ public class HazelcastConnectorTest {
 
         sessionMap = mock(IMap.class);
 
+        // disable shutdown hook to prevent logs from being flooded with warning messages
+        Config hazelcastConfig = new Config();
+        hazelcastConfig.getProperties().setProperty(ClusterProperty.SHUTDOWNHOOK_ENABLED.getName(), "false");
+
         hazelcastInstance = mock(HazelcastInstance.class);
+        when(hazelcastInstance.getConfig()).thenReturn(hazelcastConfig);
         when(hazelcastInstance.<String, byte[]> getMap(anyString()))
                 .thenReturn(sessionMap);
 


### PR DESCRIPTION
Disables Hazelcast shutdown hook to prevent premature HazelcastInstance termination before SessionSerializer completes pending serializations.

- Disable Hazelcast shutdown hook in KubernetesKitConfiguration
- Add warning log when shutdown hook is enabled in HazelcastConnector
- Add optional slow serialization simulator bean for testing

This ensures session state is fully propagated to the cluster before the backend connector is torn down during application shutdown.

Fixes #236