### PR TITLE
Make RedisConnector conditional on RedisConnectionFactory

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
@@ -268,11 +268,12 @@ public class KubernetesKitConfiguration {
 
     }
 
-    @ConditionalOnClass(DataRedisAutoConfiguration.class)
     @AutoConfiguration(after = DataRedisAutoConfiguration.class)
+    @ConditionalOnClass(DataRedisAutoConfiguration.class)
     public static class RedisConfiguration {
 
         @Bean
+        @ConditionalOnBean(RedisConnectionFactory.class)
         @ConditionalOnMissingBean
         RedisConnector redisConnector(RedisConnectionFactory factory) {
             return new RedisConnector(factory);


### PR DESCRIPTION
This pull request makes a small adjustment to the configuration of the Redis integration in `KubernetesKitConfiguration.java`. The change ensures that the `RedisConnector` bean is only created when a `RedisConnectionFactory` bean is present, when for example the Redis dependency is on the classpath but there is not configuration for the bean to be created.

Fixes #261 