### PR TITLE
fix: ensure RedisConnector bean is created by fixing auto-configuration ordering

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/HazelcastConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/HazelcastConfiguration.java
@@ -1,0 +1,87 @@
+/*-
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.kubernetes.starter;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.util.StringUtils;
+
+import com.vaadin.kubernetes.starter.sessiontracker.backend.HazelcastConnector;
+
+/**
+ * Auto-configuration for Hazelcast-based session backend.
+ */
+@AutoConfiguration
+@ConditionalOnClass(HazelcastInstance.class)
+@EnableConfigurationProperties(HazelcastProperties.class)
+public class HazelcastConfiguration {
+
+    final HazelcastProperties properties;
+
+    public HazelcastConfiguration(HazelcastProperties properties) {
+        this.properties = properties;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    HazelcastConnector hazelcastConnector(
+            HazelcastInstance hazelcastInstance) {
+        return new HazelcastConnector(hazelcastInstance);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public HazelcastInstance hazelcastInstance() {
+        final var config = new Config();
+
+        configure(config);
+        // Make sure Hazelcast shutdown hook is disabled so that the
+        // instance will be stopped after SessionSerializer saved the
+        // latest pending state
+        config.setProperty("hazelcast.shutdownhook.enabled", "false");
+        configureKubernetes(config);
+
+        return createHazelcastInstance(config);
+    }
+
+    HazelcastInstance createHazelcastInstance(Config config) {
+        return Hazelcast.newHazelcastInstance(config);
+    }
+
+    protected void configure(Config config) {
+        // Do nothing
+    }
+
+    private void configureKubernetes(Config config) {
+        final var k8sServiceName = properties.getServiceName();
+
+        if (StringUtils.hasText(k8sServiceName)) {
+            final var networkConfig = config.getNetworkConfig().getJoin();
+            networkConfig.getTcpIpConfig().setEnabled(false);
+            networkConfig.getMulticastConfig().setEnabled(false);
+
+            final var k8sConfig = networkConfig.getKubernetesConfig();
+            k8sConfig.setEnabled(true);
+
+            final var k8sNamespace = properties.getNamespace();
+            k8sConfig.setProperty("namespace", k8sNamespace);
+            k8sConfig.setProperty("service-name", k8sServiceName);
+            k8sConfig.setProperty("service-port",
+                    Integer.toString(properties.getServicePort()));
+        }
+    }
+
+}

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/HazelcastProperties.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/HazelcastProperties.java
@@ -1,0 +1,88 @@
+/*-
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.kubernetes.starter;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Hazelcast configuration properties.
+ */
+@ConfigurationProperties(prefix = "vaadin.kubernetes.hazelcast")
+public class HazelcastProperties {
+
+    private String namespace = "default";
+
+    private String serviceName;
+
+    private int servicePort = 0;
+
+    /**
+     * Gets the Kubernetes namespace to use.
+     *
+     * @return the namespace
+     */
+    public String getNamespace() {
+        return namespace;
+    }
+
+    /**
+     * Sets the Kubernetes namespace to use. If not set, the default value
+     * is {@code default}.
+     *
+     * @param namespace
+     *            the namespace
+     */
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+
+    /**
+     * Gets the service name of the Kubernetes service exposing the
+     * Hazelcast port to the cluster.
+     *
+     * @return the service name
+     */
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    /**
+     * Sets the service name of the Kubernetes service exposing the
+     * Hazelcast port to the cluster.
+     *
+     * @param serviceName
+     *            the service name
+     */
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    /**
+     * Gets endpoint port of the Hazelcast service
+     *
+     * If specified with a value greater than 0, it overrides the default; 0
+     * by default.
+     *
+     * @return endpoint port or 0
+     */
+    public int getServicePort() {
+        return servicePort;
+    }
+
+    /**
+     * Sets endpoint port of the Hazelcast service.
+     *
+     * @param port
+     *            port number or 0
+     */
+    public void setServicePort(int port) {
+        this.servicePort = port;
+    }
+}

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
@@ -16,9 +16,6 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.function.Predicate;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.core.Hazelcast;
-import com.hazelcast.core.HazelcastInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,11 +24,9 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -40,17 +35,12 @@ import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.core.annotation.Order;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.util.StringUtils;
-
 import com.vaadin.flow.spring.SpringBootAutoConfiguration;
 import com.vaadin.kubernetes.starter.sessiontracker.SessionListener;
 import com.vaadin.kubernetes.starter.sessiontracker.SessionSerializationCallback;
 import com.vaadin.kubernetes.starter.sessiontracker.SessionSerializer;
 import com.vaadin.kubernetes.starter.sessiontracker.SessionTrackerFilter;
 import com.vaadin.kubernetes.starter.sessiontracker.backend.BackendConnector;
-import com.vaadin.kubernetes.starter.sessiontracker.backend.HazelcastConnector;
-import com.vaadin.kubernetes.starter.sessiontracker.backend.RedisConnector;
 import com.vaadin.kubernetes.starter.sessiontracker.backend.SessionExpirationPolicy;
 import com.vaadin.kubernetes.starter.sessiontracker.push.PushSessionTracker;
 import com.vaadin.kubernetes.starter.sessiontracker.serialization.SerializationStreamFactory;
@@ -67,7 +57,8 @@ import com.vaadin.kubernetes.starter.ui.RollingUpdateHandler;
  */
 @AutoConfiguration
 @ConditionalOnProperty(name = "auto-configure", prefix = KubernetesKitProperties.PREFIX, matchIfMissing = true)
-@AutoConfigureAfter(SpringBootAutoConfiguration.class)
+@AutoConfigureAfter({ SpringBootAutoConfiguration.class,
+        RedisConfiguration.class, HazelcastConfiguration.class })
 @EnableConfigurationProperties({ KubernetesKitProperties.class,
         SerializationProperties.class })
 public class KubernetesKitConfiguration {
@@ -288,77 +279,4 @@ public class KubernetesKitConfiguration {
 
     }
 
-    @AutoConfiguration(after = DataRedisAutoConfiguration.class)
-    @ConditionalOnClass(DataRedisAutoConfiguration.class)
-    public static class RedisConfiguration {
-
-        @Bean
-        @ConditionalOnBean(RedisConnectionFactory.class)
-        @ConditionalOnMissingBean
-        RedisConnector redisConnector(RedisConnectionFactory factory) {
-            return new RedisConnector(factory);
-        }
-    }
-
-    @AutoConfiguration
-    @ConditionalOnClass(HazelcastInstance.class)
-    public static class HazelcastConfiguration {
-
-        final KubernetesKitProperties properties;
-
-        public HazelcastConfiguration(KubernetesKitProperties properties) {
-            this.properties = properties;
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        HazelcastConnector hazelcastConnector(
-                HazelcastInstance hazelcastInstance) {
-            return new HazelcastConnector(hazelcastInstance);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public HazelcastInstance hazelcastInstance() {
-            final var config = new Config();
-
-            configure(config);
-            // Make sure Hazelcast shutdown hook is disabled so that the
-            // instance will be stopped after SessionSerializer saved the
-            // latest pending state
-            config.setProperty("hazelcast.shutdownhook.enabled", "false");
-            configureKubernetes(config);
-
-            return createHazelcastInstance(config);
-        }
-
-        HazelcastInstance createHazelcastInstance(Config config) {
-            return Hazelcast.newHazelcastInstance(config);
-        }
-
-        protected void configure(Config config) {
-            // Do nothing
-        }
-
-        private void configureKubernetes(Config config) {
-            final var k8sProperties = properties.getHazelcast();
-            final var k8sServiceName = k8sProperties.getServiceName();
-
-            if (StringUtils.hasText(k8sServiceName)) {
-                final var networkConfig = config.getNetworkConfig().getJoin();
-                networkConfig.getTcpIpConfig().setEnabled(false);
-                networkConfig.getMulticastConfig().setEnabled(false);
-
-                final var k8sConfig = networkConfig.getKubernetesConfig();
-                k8sConfig.setEnabled(true);
-
-                final var k8sNamespace = k8sProperties.getNamespace();
-                k8sConfig.setProperty("namespace", k8sNamespace);
-                k8sConfig.setProperty("service-name", k8sServiceName);
-                k8sConfig.setProperty("service-port",
-                        Integer.toString(k8sProperties.getServicePort()));
-            }
-        }
-
-    }
 }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitProperties.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitProperties.java
@@ -119,12 +119,7 @@ public class KubernetesKitProperties {
     private String stickySessionCookieName = "INGRESSCOOKIE";
 
     /**
-     * Hazelcast configuration properties.
-     */
-    private HazelcastProperties hazelcast = new HazelcastProperties();
-
-    /**
-     * Checks if auto-configuration of {@link KubernetesKitConfiguration} is
+     * Checks if auto-configuration of Kubernetes Kit is
      * enabled.
      *
      * @return true, if auto-configuration is enabled
@@ -289,102 +284,6 @@ public class KubernetesKitProperties {
      */
     public void setStickySessionCookieName(String stickySessionCookieName) {
         this.stickySessionCookieName = stickySessionCookieName;
-    }
-
-    /**
-     * Gets Hazelcast configuration properties.
-     *
-     * @return the Hazelcast configuration properties
-     */
-    public HazelcastProperties getHazelcast() {
-        return hazelcast;
-    }
-
-    /**
-     * Sets Hazelcast configuration properties.
-     *
-     * @param hazelcast
-     *            the Hazelcast configuration properties
-     */
-    public void setHazelcast(HazelcastProperties hazelcast) {
-        this.hazelcast = hazelcast;
-    }
-
-    /**
-     * Hazelcast configuration properties.
-     */
-    public static class HazelcastProperties {
-
-        private String namespace = "default";
-
-        private String serviceName;
-
-        private int servicePort = 0;
-
-        /**
-         * Gets the Kubernetes namespace to use.
-         *
-         * @return the namespace
-         */
-        public String getNamespace() {
-            return namespace;
-        }
-
-        /**
-         * Sets the Kubernetes namespace to use. If not set, the default value
-         * is {@code default}.
-         *
-         * @param namespace
-         *            the namespace
-         */
-        public void setNamespace(String namespace) {
-            this.namespace = namespace;
-        }
-
-        /**
-         * Gets the service name of the Kubernetes service exposing the
-         * Hazelcast port to the cluster.
-         *
-         * @return the service name
-         */
-        public String getServiceName() {
-            return serviceName;
-        }
-
-        /**
-         * Sets the service name of the Kubernetes service exposing the
-         * Hazelcast port to the cluster.
-         *
-         * @param serviceName
-         *            the service name
-         */
-        public void setServiceName(String serviceName) {
-            this.serviceName = serviceName;
-        }
-
-        /**
-         * Gets endpoint port of the Hazelcast service
-         *
-         * If specified with a value greater than 0, it overrides the default; 0
-         * by default.
-         *
-         * @return endpoint port or 0
-         */
-        public int getServicePort() {
-            return servicePort;
-        }
-
-        /**
-         * Sets endpoint port of the Hazelcast service.
-         *
-         * Uxd
-         *
-         * @param port
-         *            port number or 0
-         */
-        public void setServicePort(int port) {
-            this.servicePort = port;
-        }
     }
 
 }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/RedisConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/RedisConfiguration.java
@@ -1,0 +1,35 @@
+/*-
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.kubernetes.starter;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+import com.vaadin.kubernetes.starter.sessiontracker.backend.RedisConnector;
+
+/**
+ * Auto-configuration for Redis-based session backend.
+ */
+@AutoConfiguration(after = DataRedisAutoConfiguration.class)
+@ConditionalOnClass(DataRedisAutoConfiguration.class)
+public class RedisConfiguration {
+
+    @Bean
+    @ConditionalOnBean(RedisConnectionFactory.class)
+    @ConditionalOnMissingBean
+    RedisConnector redisConnector(RedisConnectionFactory factory) {
+        return new RedisConnector(factory);
+    }
+}

--- a/kubernetes-kit-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kubernetes-kit-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,3 @@
 com.vaadin.kubernetes.starter.KubernetesKitConfiguration
+com.vaadin.kubernetes.starter.RedisConfiguration
+com.vaadin.kubernetes.starter.HazelcastConfiguration

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/KubernetesKitConfigurationTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/KubernetesKitConfigurationTest.java
@@ -50,9 +50,9 @@ class KubernetesKitConfigurationTest {
 
     @Test
     public void hazelcastInstance_serviceNameSet_kubernetesConfigured() {
-        var prop = new KubernetesKitProperties();
-        prop.getHazelcast().setNamespace("foo-namespace");
-        prop.getHazelcast().setServiceName("foo-service");
+        var prop = new HazelcastProperties();
+        prop.setNamespace("foo-namespace");
+        prop.setServiceName("foo-service");
 
         var configuration = new MockHazelcastConfiguration(prop);
 
@@ -72,9 +72,9 @@ class KubernetesKitConfigurationTest {
     }
 
     private final class MockHazelcastConfiguration
-            extends KubernetesKitConfiguration.HazelcastConfiguration {
+            extends HazelcastConfiguration {
 
-        public MockHazelcastConfiguration(KubernetesKitProperties properties) {
+        public MockHazelcastConfiguration(HazelcastProperties properties) {
             super(properties);
         }
 


### PR DESCRIPTION
## Summary
- Extract `RedisConfiguration` and `HazelcastConfiguration` from nested inner classes to top-level auto-configuration classes registered in `AutoConfiguration.imports`
- Spring Boot ignores `@AutoConfiguration` ordering annotations on nested classes, so `@AutoConfiguration(after = DataRedisAutoConfiguration.class)` on the inner `RedisConfiguration` was silently ignored, causing `RedisConnector` to never be created
- Extract `HazelcastProperties` to its own `@ConfigurationProperties` class (same `vaadin.kubernetes.hazelcast` prefix, non-breaking)
- Add `@AutoConfigureAfter` for `RedisConfiguration` and `HazelcastConfiguration` on `KubernetesKitConfiguration` so backend connector beans exist when `@ConditionalOnBean(BackendConnector.class)` is evaluated

## Test plan
- [x] Existing tests pass (56 tests, 0 failures)
- [x] Verified on a local K8s cluster with Redis: `RedisConnector` bean is created and session serialization works (serialization logs visible after each request)