### PR TITLE
fix: initialize SerializationProperties in InitListener no-arg constructor

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
@@ -355,6 +355,7 @@ public class SerializationDebugRequestHandler
         public SerializationProperties serializationProperties;
 
         public InitListener() {
+            this(new SerializationProperties());
         }
 
         public InitListener(SerializationProperties serializationProperties) {


### PR DESCRIPTION
## Summary
- The `InitListener` no-arg constructor left `serializationProperties` null, causing an NPE in `SessionSerializer` when not instantiated via the Spring bean factory
- Delegate to the parameterized constructor with a default `SerializationProperties` instance

Fixes #276

## Test plan
- [x] Existing `SerializationDebugRequestHandlerTest` tests pass (13/13)
- [x] Existing `SessionSerializerTest` tests pass (25/25)