### PR TITLE
fix: initialize VaadinService on debug handler's SessionSerializer

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandler.java
@@ -379,9 +379,10 @@ public class SerializationDebugRequestHandler
             } else {
                 logger.info(
                         "Installing SerializationDebugRequestHandler for session serialization debug");
-                serviceInitEvent
-                        .addRequestHandler(new SerializationDebugRequestHandler(
-                                serializationProperties));
+                SerializationDebugRequestHandler handler = new SerializationDebugRequestHandler(
+                        serializationProperties);
+                handler.sessionSerializer.serviceInit(serviceInitEvent);
+                serviceInitEvent.addRequestHandler(handler);
             }
         }
     }

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandlerInitListenerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandlerInitListenerTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.kubernetes.starter.sessiontracker.serialization.debug;
 
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -11,6 +12,7 @@ import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
+import com.vaadin.kubernetes.starter.sessiontracker.SessionSerializer;
 import com.vaadin.kubernetes.starter.test.EnableOnJavaIOReflection;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,6 +38,29 @@ class SerializationDebugRequestHandlerInitListenerTest {
         assertThat(handlers).hasSize(1);
         assertThat(handlers.get(0))
                 .isExactlyInstanceOf(SerializationDebugRequestHandler.class);
+    }
+
+    @Test
+    void developmentModeAndSerializationDebugEnabled_sessionSerializerReceivesVaadinService()
+            throws Exception {
+        ServiceInitEvent event = createEvent(false, true);
+        listener.serviceInit(event);
+
+        SerializationDebugRequestHandler handler = (SerializationDebugRequestHandler) event
+                .getAddedRequestHandlers().findFirst().orElseThrow();
+
+        Field serializerField = SerializationDebugRequestHandler.class
+                .getDeclaredField("sessionSerializer");
+        serializerField.setAccessible(true);
+        SessionSerializer serializer = (SessionSerializer) serializerField
+                .get(handler);
+
+        Field serviceField = SessionSerializer.class
+                .getDeclaredField("vaadinService");
+        serviceField.setAccessible(true);
+        VaadinService service = (VaadinService) serviceField.get(serializer);
+
+        assertThat(service).isSameAs(event.getSource());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #279.

- Forward the `ServiceInitEvent` to the debug handler's private `SessionSerializer` in `InitListener.serviceInit()`, so it gets the `VaadinService` reference needed during deserialization
- Add regression test verifying the installed handler's serializer receives the `VaadinService`

## Context

The `SerializationDebugRequestHandler` creates its own `SessionSerializer` instance, but never called `serviceInit()` on it. Its `Filter.doFilter()` runs deserialization **after** `chain.doFilter()` returns, when Vaadin has already cleared `CurrentInstance` thread-locals. With both `SessionSerializer.vaadinService` and `VaadinService.getCurrent()` null, `UnserializableComponentWrapper.restoreComponent()` cannot inject a `VaadinService` into the deserialized `VaadinSession`, causing a NPE when `ComponentUtil.setJavaClassNameInDevelopment()` (introduced in Flow 25) tries to read the deployment configuration.

## Test plan

- [ ] `SerializationDebugRequestHandlerInitListenerTest` passes (including new `sessionSerializerReceivesVaadinService` test)
- [ ] Full `kubernetes-kit-starter` test suite passes
- [ ] New test fails when the fix is reverted (verified locally)