### PR TITLE
ci: add integration test for session replication

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,7 +1,7 @@
 name: Integration Test
 on:
   push:
-    branches: [main]
+    branches: [main, feat/integration-test-session-replication]
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,7 +1,7 @@
 name: Integration Test
 on:
   push:
-    branches: [main, feat/integration-test-session-replication]
+    branches: [main]
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -37,11 +37,14 @@ jobs:
           mkdir -p ~/.vaadin/
           echo '{"username":"'$(echo $VAADIN_PRO_KEY | cut -d / -f1)'","proKey":"'$(echo $VAADIN_PRO_KEY | cut -d / -f2)'"}' > ~/.vaadin/proKey
 
+      - name: Build starter
+        run: mvn install -B -e -ntp -pl :kubernetes-kit-starter -am -DskipTests
+
       - name: Build demo image with Buildpacks
         run: |
           set -x -e -o pipefail
           mvn spring-boot:build-image -B -e -ntp \
-            -pl :kubernetes-kit-demo -am \
+            -pl :kubernetes-kit-demo \
             -Pproduction,redis \
             -DskipTests \
             -Dspring-boot.build-image.imageName=${{ env.IMAGE_NAME }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,133 @@
+name: Integration Test
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  merge_group:
+permissions:
+  contents: read
+concurrency:
+  group: it-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  _HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+  JAVA_VERSION: '21'
+  IMAGE_NAME: kubernetes-kit-demo:test
+jobs:
+  integration-test:
+    environment: ${{ github.event.pull_request.head.repo.fork && 'pr-tests' || '' }}
+    timeout-minutes: 45
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check secrets
+        env:
+          VAADIN_PRO_KEY: ${{ secrets.VAADIN_PRO_KEY }}
+        run: |
+          [ -z "$VAADIN_PRO_KEY" ] \
+            && echo "VAADIN_PRO_KEY is not defined" | tee -a $GITHUB_STEP_SUMMARY && exit 1 || exit 0
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ env._HEAD_SHA || github.sha }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
+
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.8.7
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-it-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Set TB License
+        env:
+          VAADIN_PRO_KEY: ${{ secrets.VAADIN_PRO_KEY }}
+        run: |
+          mkdir -p ~/.vaadin/
+          echo '{"username":"'$(echo $VAADIN_PRO_KEY | cut -d / -f1)'","proKey":"'$(echo $VAADIN_PRO_KEY | cut -d / -f2)'"}' > ~/.vaadin/proKey
+
+      - name: Build demo image with Buildpacks
+        run: |
+          set -x -e -o pipefail
+          mvn spring-boot:build-image -B -e -ntp \
+            -pl :kubernetes-kit-demo -am \
+            -Pproduction,redis \
+            -DskipTests \
+            -Dspring-boot.build-image.imageName=${{ env.IMAGE_NAME }}
+
+      - name: Create kind cluster
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind create cluster --name kit-test --wait 60s
+
+      - name: Load image into kind
+        run: kind load docker-image ${{ env.IMAGE_NAME }} --name kit-test
+
+      - name: Install Envoy Gateway
+        run: |
+          kubectl apply --server-side -f https://github.com/envoyproxy/gateway/releases/download/v1.3.0/install.yaml
+          kubectl wait --timeout=5m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
+
+      - name: Deploy application stack
+        run: |
+          kubectl apply -f kubernetes-kit-demo/deployment/gateway.yaml
+          kubectl apply -f kubernetes-kit-demo/deployment/redis.yaml
+          kubectl apply -f kubernetes-kit-demo/src/test/resources/k8s/
+
+      - name: Wait for deployments to be ready
+        run: |
+          kubectl wait --timeout=5m deployment/kubernetes-kit-redis --for=condition=Available
+          kubectl wait --timeout=5m deployment/kubernetes-kit-demo --for=condition=Available
+          kubectl wait --timeout=5m -n envoy-gateway-system \
+            -l gateway.envoyproxy.io/owning-gateway-name=public-gateway \
+            deployment --for=condition=Available
+
+      - name: Port-forward Envoy Gateway
+        run: |
+          ENVOY_SVC=$(kubectl get svc -n envoy-gateway-system \
+            -l gateway.envoyproxy.io/owning-gateway-name=public-gateway \
+            -o jsonpath='{.items[0].metadata.name}')
+          kubectl -n envoy-gateway-system port-forward "svc/${ENVOY_SVC}" 8080:80 &
+          echo "ENVOY_PORT_FORWARD_PID=$!" >> $GITHUB_ENV
+          # Wait for port-forward to be ready
+          for i in $(seq 1 30); do
+            curl -s -o /dev/null http://localhost:8080 && break || sleep 2
+          done
+
+      - name: Install Playwright browsers
+        run: mvn exec:java -pl :kubernetes-kit-demo -Pintegration-test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install chromium --with-deps"
+
+      - name: Run integration tests
+        run: |
+          mvn verify -B -e -ntp \
+            -pl :kubernetes-kit-demo \
+            -Pintegration-test \
+            -Dapp.url=http://localhost:8080
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== Pod status ===" && kubectl get pods -o wide
+          echo "=== App logs ===" && kubectl logs -l app=kubernetes-kit-demo --all-containers --tail=200
+          echo "=== Redis logs ===" && kubectl logs -l app=kubernetes-kit-redis --tail=50
+          echo "=== Events ===" && kubectl get events --sort-by='.lastTimestamp'
+
+      - name: Cleanup
+        if: always()
+        run: |
+          kill $ENVOY_PORT_FORWARD_PID 2>/dev/null || true
+          kind delete cluster --name kit-test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     branches: [main]
   merge_group:
@@ -18,6 +18,7 @@ env:
   IMAGE_NAME: kubernetes-kit-demo:test
 jobs:
   integration-test:
+    environment: ${{ github.event.pull_request.head.repo.fork && 'pr-tests' || '' }}
     timeout-minutes: 45
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -23,13 +23,6 @@ jobs:
     timeout-minutes: 45
     runs-on: ubuntu-24.04
     steps:
-      - name: Check secrets
-        env:
-          VAADIN_PRO_KEY: ${{ secrets.VAADIN_PRO_KEY }}
-        run: |
-          [ -z "$VAADIN_PRO_KEY" ] \
-            && echo "VAADIN_PRO_KEY is not defined" | tee -a $GITHUB_STEP_SUMMARY && exit 1 || exit 0
-
       - uses: actions/checkout@v5
         with:
           ref: ${{ env._HEAD_SHA || github.sha }}
@@ -39,17 +32,7 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
-
-      - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
-        with:
-          maven-version: 3.8.7
-
-      - uses: actions/cache@v5
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-it-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
+          cache: 'maven'
 
       - name: Set TB License
         env:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -50,18 +50,16 @@ jobs:
             -Dspring-boot.build-image.imageName=${{ env.IMAGE_NAME }}
 
       - name: Create kind cluster
-        run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
-          kind create cluster --name kit-test --wait 60s
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: kit-test
 
       - name: Load image into kind
         run: kind load docker-image ${{ env.IMAGE_NAME }} --name kit-test
 
       - name: Install Envoy Gateway
         run: |
-          kubectl apply --server-side -f https://github.com/envoyproxy/gateway/releases/download/v1.3.0/install.yaml
+          kubectl apply --server-side -f https://github.com/envoyproxy/gateway/releases/download/v1.7.2/install.yaml
           kubectl wait --timeout=5m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
 
       - name: Deploy application stack
@@ -74,24 +72,25 @@ jobs:
         run: |
           kubectl wait --timeout=5m deployment/kubernetes-kit-redis --for=condition=Available
           kubectl wait --timeout=5m deployment/kubernetes-kit-demo --for=condition=Available
-          kubectl wait --timeout=5m -n envoy-gateway-system \
+          # Envoy proxy is created in the Gateway's namespace (default)
+          kubectl wait --timeout=5m \
             -l gateway.envoyproxy.io/owning-gateway-name=public-gateway \
             deployment --for=condition=Available
 
       - name: Port-forward Envoy Gateway
         run: |
-          ENVOY_SVC=$(kubectl get svc -n envoy-gateway-system \
+          ENVOY_SVC=$(kubectl get svc \
             -l gateway.envoyproxy.io/owning-gateway-name=public-gateway \
             -o jsonpath='{.items[0].metadata.name}')
-          kubectl -n envoy-gateway-system port-forward "svc/${ENVOY_SVC}" 8080:80 &
+          kubectl port-forward "svc/${ENVOY_SVC}" 8080:80 &
           echo "ENVOY_PORT_FORWARD_PID=$!" >> $GITHUB_ENV
           # Wait for port-forward to be ready
           for i in $(seq 1 30); do
-            curl -s -o /dev/null http://localhost:8080 && break || sleep 2
+            curl -sf -o /dev/null http://localhost:8080 && break || sleep 2
           done
 
       - name: Install Playwright browsers
-        run: mvn exec:java -pl :kubernetes-kit-demo -Pintegration-test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install chromium --with-deps"
+        run: mvn exec:java -pl :kubernetes-kit-demo -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install chromium --with-deps"
 
       - name: Run integration tests
         run: |
@@ -110,6 +109,4 @@ jobs:
 
       - name: Cleanup
         if: always()
-        run: |
-          kill $ENVOY_PORT_FORWARD_PID 2>/dev/null || true
-          kind delete cluster --name kit-test
+        run: kill $ENVOY_PORT_FORWARD_PID 2>/dev/null || true

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -22,83 +22,70 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
-
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
           cache: 'maven'
-
       - name: Set TB License
         env:
           VAADIN_PRO_KEY: ${{ secrets.VAADIN_PRO_KEY }}
         run: |
           mkdir -p ~/.vaadin/
           echo '{"username":"'$(echo $VAADIN_PRO_KEY | cut -d / -f1)'","proKey":"'$(echo $VAADIN_PRO_KEY | cut -d / -f2)'"}' > ~/.vaadin/proKey
-
       - name: Build starter
         run: mvn install -B -e -ntp -pl :kubernetes-kit-starter -am -DskipTests
-
       - name: Build demo image with Buildpacks
         run: |
-          set -x -e -o pipefail
           mvn spring-boot:build-image -B -e -ntp \
             -pl :kubernetes-kit-demo \
             -Pproduction,redis \
             -DskipTests \
             -Dspring-boot.build-image.imageName=${{ env.IMAGE_NAME }}
-
       - name: Create kind cluster
         uses: helm/kind-action@v1
         with:
           cluster_name: kit-test
-
       - name: Load image into kind
         run: kind load docker-image ${{ env.IMAGE_NAME }} --name kit-test
-
       - name: Install Envoy Gateway
         run: |
           kubectl apply --server-side -f https://github.com/envoyproxy/gateway/releases/download/v1.7.2/install.yaml
           kubectl wait --timeout=5m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
-
       - name: Deploy application stack
         run: |
           kubectl apply -f kubernetes-kit-demo/deployment/gateway.yaml
           kubectl apply -f kubernetes-kit-demo/deployment/redis.yaml
           kubectl apply -f kubernetes-kit-demo/src/test/resources/k8s/
-
       - name: Wait for deployments to be ready
         run: |
           kubectl wait --timeout=5m deployment/kubernetes-kit-redis --for=condition=Available
           kubectl wait --timeout=5m deployment/kubernetes-kit-demo --for=condition=Available
-          # Envoy proxy is created in the Gateway's namespace (default)
-          kubectl wait --timeout=5m \
+          kubectl wait --timeout=5m -n envoy-gateway-system \
             -l gateway.envoyproxy.io/owning-gateway-name=public-gateway \
             deployment --for=condition=Available
-
-      - name: Port-forward Envoy Gateway
+      - name: Verify application is running
         run: |
-          ENVOY_SVC=$(kubectl get svc \
+          ENVOY_SVC=$(kubectl get svc -n envoy-gateway-system \
             -l gateway.envoyproxy.io/owning-gateway-name=public-gateway \
             -o jsonpath='{.items[0].metadata.name}')
-          kubectl port-forward "svc/${ENVOY_SVC}" 8080:80 &
+          kubectl -n envoy-gateway-system port-forward "svc/${ENVOY_SVC}" 8080:80 &
           echo "ENVOY_PORT_FORWARD_PID=$!" >> $GITHUB_ENV
-          # Wait for port-forward to be ready
           for i in $(seq 1 30); do
             curl -sf -o /dev/null http://localhost:8080 && break || sleep 2
           done
-
+          curl -sf http://localhost:8080/ | grep -q 'Vaadin' || (echo "App not responding correctly" && exit 1)
+          echo "No errors in app logs:"
+          kubectl logs -l app=kubernetes-kit-demo --tail=50 | grep -c ERROR | xargs -I{} test {} -eq 0
       - name: Install Playwright browsers
-        run: mvn exec:java -pl :kubernetes-kit-demo -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install chromium --with-deps"
-
+        run: npx playwright install chromium --with-deps
       - name: Run integration tests
         run: |
           mvn verify -B -e -ntp \
             -pl :kubernetes-kit-demo \
             -Pintegration-test \
             -Dapp.url=http://localhost:8080
-
       - name: Collect logs on failure
         if: failure()
         run: |
@@ -106,7 +93,6 @@ jobs:
           echo "=== App logs ===" && kubectl logs -l app=kubernetes-kit-demo --all-containers --tail=200
           echo "=== Redis logs ===" && kubectl logs -l app=kubernetes-kit-redis --tail=50
           echo "=== Events ===" && kubectl get events --sort-by='.lastTimestamp'
-
       - name: Cleanup
         if: always()
         run: kill $ENVOY_PORT_FORWARD_PID 2>/dev/null || true

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
   merge_group:
@@ -14,18 +14,14 @@ concurrency:
   cancel-in-progress: true
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  _HEAD_SHA: ${{ github.event.pull_request.head.sha }}
   JAVA_VERSION: '21'
   IMAGE_NAME: kubernetes-kit-demo:test
 jobs:
   integration-test:
-    environment: ${{ github.event.pull_request.head.repo.fork && 'pr-tests' || '' }}
     timeout-minutes: 45
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ env._HEAD_SHA || github.sha }}
 
       - name: Set up JDK
         uses: actions/setup-java@v5

--- a/.github/workflows/kubernetes-test.yml
+++ b/.github/workflows/kubernetes-test.yml
@@ -1,4 +1,4 @@
-name: Integration Test
+name: Kubernetes Test
 on:
   push:
     branches: [main]
@@ -10,19 +10,22 @@ on:
 permissions:
   contents: read
 concurrency:
-  group: it-${{ github.head_ref || github.ref_name }}
+  group: k8s-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  _HEAD_SHA: ${{ github.event.pull_request.head.sha }}
   JAVA_VERSION: '21'
   IMAGE_NAME: kubernetes-kit-demo:test
 jobs:
-  integration-test:
+  kubernetes-test:
     environment: ${{ github.event.pull_request.head.repo.fork && 'pr-tests' || '' }}
     timeout-minutes: 45
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ env._HEAD_SHA || github.sha }}
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -73,27 +76,34 @@ jobs:
             -o jsonpath='{.items[0].metadata.name}')
           kubectl -n envoy-gateway-system port-forward "svc/${ENVOY_SVC}" 8080:80 &
           echo "ENVOY_PORT_FORWARD_PID=$!" >> $GITHUB_ENV
-          for i in $(seq 1 30); do
-            curl -sf -o /dev/null http://localhost:8080 && break || sleep 2
-          done
-          curl -sf http://localhost:8080/ | grep -q 'Vaadin' || (echo "App not responding correctly" && exit 1)
-          echo "No errors in app logs:"
+          timeout 60 bash -c 'until curl -sf http://localhost:8080 >/dev/null; do sleep 2; done' \
+            || (echo "Port-forward never became ready" && exit 1)
+          curl -sf http://localhost:8080/ | grep -q 'Vaadin' \
+            || (echo "App not responding correctly" && exit 1)
           kubectl logs -l app=kubernetes-kit-demo --tail=50 | grep -c ERROR | xargs -I{} test {} -eq 0
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps
-      - name: Run integration tests
+      - name: Run Kubernetes integration tests
         run: |
           mvn verify -B -e -ntp \
             -pl :kubernetes-kit-demo \
             -Pintegration-test \
+            -Dfailsafe.excludedGroups= \
             -Dapp.url=http://localhost:8080
       - name: Collect logs on failure
         if: failure()
         run: |
-          echo "=== Pod status ===" && kubectl get pods -o wide
-          echo "=== App logs ===" && kubectl logs -l app=kubernetes-kit-demo --all-containers --tail=200
-          echo "=== Redis logs ===" && kubectl logs -l app=kubernetes-kit-redis --tail=50
-          echo "=== Events ===" && kubectl get events --sort-by='.lastTimestamp'
+          mkdir -p k8s-logs
+          kubectl get pods -o wide > k8s-logs/pod-status.txt
+          kubectl logs -l app=kubernetes-kit-demo --all-containers --prefix --tail=-1 > k8s-logs/app.log
+          kubectl logs -l app=kubernetes-kit-redis --tail=-1 > k8s-logs/redis.log
+          kubectl logs -n envoy-gateway-system -l gateway.envoyproxy.io/owning-gateway-name=public-gateway --tail=-1 > k8s-logs/envoy.log || true
+          kubectl get events --sort-by='.lastTimestamp' > k8s-logs/events.txt
+      - uses: actions/upload-artifact@v5
+        if: failure()
+        with:
+          name: k8s-logs
+          path: k8s-logs/
       - name: Cleanup
         if: always()
         run: kill $ENVOY_PORT_FORWARD_PID 2>/dev/null || true

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ target/
 
 *.iml
 .DS_Store
+.secrets
 

--- a/kubernetes-kit-demo/pom.xml
+++ b/kubernetes-kit-demo/pom.xml
@@ -64,6 +64,17 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+            <version>1.52.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -120,19 +131,6 @@
 
         <profile>
             <id>integration-test</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.microsoft.playwright</groupId>
-                    <artifactId>playwright</artifactId>
-                    <version>1.52.0</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.junit.jupiter</groupId>
-                    <artifactId>junit-jupiter</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>

--- a/kubernetes-kit-demo/pom.xml
+++ b/kubernetes-kit-demo/pom.xml
@@ -119,6 +119,45 @@
         </profile>
 
         <profile>
+            <id>integration-test</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.microsoft.playwright</groupId>
+                    <artifactId>playwright</artifactId>
+                    <version>1.52.0</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${maven.surefire.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <app.url>${app.url}</app.url>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>production</id>
             <build>
                 <plugins>

--- a/kubernetes-kit-demo/pom.xml
+++ b/kubernetes-kit-demo/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <maven.source.skip>true</maven.source.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
+        <failsafe.excludedGroups>kubernetes</failsafe.excludedGroups>
     </properties>
 
     <dependencies>
@@ -146,6 +147,7 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <excludedGroups>${failsafe.excludedGroups}</excludedGroups>
                             <systemPropertyVariables>
                                 <app.url>${app.url}</app.url>
                             </systemPropertyVariables>

--- a/kubernetes-kit-demo/src/test/java/com/vaadin/kubernetes/demo/it/SessionReplicationIT.java
+++ b/kubernetes-kit-demo/src/test/java/com/vaadin/kubernetes/demo/it/SessionReplicationIT.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.LocatorAssertions;
 import com.microsoft.playwright.junit.UsePlaywright;
 import com.microsoft.playwright.options.AriaRole;
 
@@ -28,8 +29,9 @@ class SessionReplicationIT {
                 new Page.GetByRoleOptions().setName("Increment"));
 
         // Wait for Vaadin to fully bootstrap (constructor calls count(),
-        // setting counter to 1)
-        assertThat(counter).hasText("1");
+        // setting counter to 1). Production mode may take a while.
+        assertThat(counter).hasText("1",
+                new LocatorAssertions.HasTextOptions().setTimeout(30_000));
 
         // Click increment a few times to trigger UIDL requests and
         // serialization

--- a/kubernetes-kit-demo/src/test/java/com/vaadin/kubernetes/demo/it/SessionReplicationIT.java
+++ b/kubernetes-kit-demo/src/test/java/com/vaadin/kubernetes/demo/it/SessionReplicationIT.java
@@ -11,8 +11,10 @@ import com.microsoft.playwright.assertions.LocatorAssertions;
 import com.microsoft.playwright.junit.UsePlaywright;
 import com.microsoft.playwright.options.AriaRole;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("kubernetes")
 @UsePlaywright
 class SessionReplicationIT {
 

--- a/kubernetes-kit-demo/src/test/java/com/vaadin/kubernetes/demo/it/SessionReplicationIT.java
+++ b/kubernetes-kit-demo/src/test/java/com/vaadin/kubernetes/demo/it/SessionReplicationIT.java
@@ -1,0 +1,81 @@
+package com.vaadin.kubernetes.demo.it;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.IOException;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.junit.UsePlaywright;
+import com.microsoft.playwright.options.AriaRole;
+
+import org.junit.jupiter.api.Test;
+
+@UsePlaywright
+class SessionReplicationIT {
+
+    static final String APP_URL = System.getProperty("app.url",
+            "http://localhost:8080");
+
+    @Test
+    void sessionIsPreservedAfterPodFailover(Page page) throws Exception {
+        page.navigate(APP_URL + "/push-counter");
+
+        Locator counter = page.locator(".counter");
+        Locator hostname = page.locator(".hostname");
+        Locator incrementBtn = page.getByRole(AriaRole.BUTTON,
+                new Page.GetByRoleOptions().setName("Increment"));
+
+        // Wait for the page to fully load (constructor calls count(),
+        // setting counter to 1)
+        assertThat(counter).not().hasText("");
+
+        // Click increment a few times to trigger UIDL requests and
+        // serialization
+        for (int i = 0; i < 3; i++) {
+            incrementBtn.click();
+        }
+
+        // Wait for the last click to be processed
+        assertThat(counter).hasText("4");
+
+        String servingPod = hostname.textContent().trim();
+
+        // Allow time for serialization to Redis after the last UIDL
+        // request
+        page.waitForTimeout(3000);
+
+        // Delete the pod that is serving our session
+        deletePod(servingPod);
+
+        // Vaadin push detects the connection loss and reconnects to the
+        // surviving pod. The session is restored from Redis. Wait for
+        // the UI to become interactive again (generous timeout to
+        // account for pod shutdown, endpoint removal, and
+        // reconnection).
+        incrementBtn.click(
+                new Locator.ClickOptions().setTimeout(120_000));
+
+        // Counter should have continued from 4 (now 5)
+        assertThat(counter).hasText("5");
+
+        // Hostname should be different (served by surviving pod)
+        String newPod = hostname.textContent().trim();
+        assertNotEquals(servingPod, newPod,
+                "Request should be served by a different pod");
+    }
+
+    static void deletePod(String podName) throws Exception {
+        Process process = new ProcessBuilder("kubectl", "delete", "pod",
+                podName, "--grace-period=0", "--force")
+                        .redirectErrorStream(true).start();
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            String output = new String(
+                    process.getInputStream().readAllBytes());
+            throw new IOException("kubectl delete pod failed (exit "
+                    + exitCode + "): " + output);
+        }
+    }
+}

--- a/kubernetes-kit-demo/src/test/java/com/vaadin/kubernetes/demo/it/SessionReplicationIT.java
+++ b/kubernetes-kit-demo/src/test/java/com/vaadin/kubernetes/demo/it/SessionReplicationIT.java
@@ -27,9 +27,9 @@ class SessionReplicationIT {
         Locator incrementBtn = page.getByRole(AriaRole.BUTTON,
                 new Page.GetByRoleOptions().setName("Increment"));
 
-        // Wait for the page to fully load (constructor calls count(),
+        // Wait for Vaadin to fully bootstrap (constructor calls count(),
         // setting counter to 1)
-        assertThat(counter).not().hasText("");
+        assertThat(counter).hasText("1");
 
         // Click increment a few times to trigger UIDL requests and
         // serialization

--- a/kubernetes-kit-demo/src/test/resources/k8s/app.yaml
+++ b/kubernetes-kit-demo/src/test/resources/k8s/app.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubernetes-kit-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kubernetes-kit-demo
+  template:
+    metadata:
+      labels:
+        app: kubernetes-kit-demo
+    spec:
+      containers:
+        - name: kubernetes-kit-demo
+          image: kubernetes-kit-demo:test
+          imagePullPolicy: Never
+          env:
+            - name: APP_VERSION
+              value: test
+          ports:
+            - name: http
+              containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes-kit-demo
+spec:
+  selector:
+    app: kubernetes-kit-demo
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/kubernetes-kit-demo/src/test/resources/k8s/route.yaml
+++ b/kubernetes-kit-demo/src/test/resources/k8s/route.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kubernetes-kit-demo
+spec:
+  parentRefs:
+    - name: public-gateway
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: kubernetes-kit-demo
+          port: 80
+      sessionPersistence:
+        sessionName: vaadin-session
+        type: Cookie

--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
         <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <flow.version>25.0-SNAPSHOT</flow.version>
+        <flow.version>25.1-SNAPSHOT</flow.version>
         <testbench.version>10.0.0</testbench.version>
-        <spring.boot.version>4.0.0</spring.boot.version>
+        <spring.boot.version>4.0.4</spring.boot.version>
         <maven.jar.version>3.3.0</maven.jar.version>
         <maven.source.version>3.2.1</maven.source.version>
         <maven.javadoc.version>3.4.1</maven.javadoc.version>


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that builds the demo app as a Docker image (Spring Boot Buildpacks, Redis backend), deploys it to a **kind** cluster with **Envoy Gateway** and sticky session cookies, and runs a **Playwright Java/JUnit** test that verifies session replication works across pod failures
- The test navigates to the PushCounterView, increments the counter, deletes the serving pod, waits for Vaadin's push reconnection, and asserts the counter state was preserved on the surviving pod
- Adds an `integration-test` Maven profile to the demo module with Playwright and maven-failsafe-plugin dependencies

## Test plan

- [ ] Integration test workflow runs successfully on this branch (triggered via `push`)
- [ ] Playwright test passes: counter value preserved after pod deletion, hostname changes
- [ ] Revert the temporary branch trigger commit before merging