### PR TITLE
chore: update demo project for Vaadin 25

### DIFF
--- a/kubernetes-kit-demo/README.md
+++ b/kubernetes-kit-demo/README.md
@@ -29,7 +29,7 @@ Build the production JAR and create a container image using the Spring Boot Mave
 Use `-Dspring-boot.build-image.imageName` to set the image name and tag:
 
 ```
-mvn clean spring-boot:build-image -pl :kubernetes-kit-demo -Pproduction,redis -Dspring-boot.build-image.imageName=kubernetes-kit-demo:1.0.0
+mvn clean spring-boot:build-image -pl :kubernetes-kit-demo -Predis -Dspring-boot.build-image.imageName=kubernetes-kit-demo:1.0.0
 ```
 
 To publish the image to a local registry (e.g., for kind or minikube):
@@ -101,7 +101,7 @@ Try incrementing the counter again. The request will be redirected to another po
 ### 1. Build and deploy the new version
 
 ```
-mvn clean spring-boot:build-image -pl :kubernetes-kit-demo -Pproduction,redis -Dspring-boot.build-image.imageName=kubernetes-kit-demo:2.0.0
+mvn clean spring-boot:build-image -pl :kubernetes-kit-demo -Predis -Dspring-boot.build-image.imageName=kubernetes-kit-demo:2.0.0
 kubectl apply -f deployment/app-v2.yaml
 ```
 

--- a/kubernetes-kit-demo/pom.xml
+++ b/kubernetes-kit-demo/pom.xml
@@ -88,7 +88,7 @@
                 <executions>
                     <execution>
                         <goals>
-                            <goal>prepare-frontend</goal>
+                            <goal>build-frontend</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -116,30 +116,6 @@
                     <artifactId>hazelcast</artifactId>
                 </dependency>
             </dependencies>
-        </profile>
-
-        <profile>
-            <id>production</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.vaadin</groupId>
-                        <artifactId>flow-maven-plugin</artifactId>
-                        <version>${flow.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>build-frontend</goal>
-                                </goals>
-                                <phase>compile</phase>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <productionMode>true</productionMode>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
     </profiles>


### PR DESCRIPTION
Replaces obsolete `prepare-frontend` with `build-frontend` in main `build` section and removes useless production profile.