### PR TITLE
test: remove timing race in serialization timeout test

### DIFF
--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/SessionSerializerTest.java
@@ -514,21 +514,39 @@ class SessionSerializerTest {
         doAnswer(i -> completed.add(i.getArgument(0))).when(connector)
                 .markSerializationComplete(anyString());
 
+        // Block session1's serialization on a latch so the concurrency
+        // ordering is deterministic: session2 is allowed to complete first,
+        // then session1 is released. This avoids flakes caused by
+        // Thread.sleep timing drift on loaded runners.
+        CountDownLatch session1Release = new CountDownLatch(1);
         String sid1 = UUID.randomUUID().toString();
         HttpSession session1 = newHttpSession(sid1);
-        session1.setAttribute("DELAY", new SerializationDelay(300));
+        session1.setAttribute("BLOCK", new BlockingSerialization(session1Release));
         vaadinService.newMockSession(session1);
 
         String sid2 = UUID.randomUUID().toString();
         HttpSession session2 = newHttpSession(sid2);
-        session2.setAttribute("DELAY", new SerializationDelay(100));
         vaadinService.newMockSession(session2);
 
-        serializer.serialize(session1);
-        Thread.sleep(100);
-        serializer.serialize(session2);
+        try {
+            serializer.serialize(session1);
+            // Wait for session1 to actually start serializing before
+            // scheduling session2, so 'started' order is deterministic.
+            await().atMost(1000, MILLISECONDS).until(() -> started.size() == 1);
+            serializer.serialize(session2);
 
-        await().atMost(1000, MILLISECONDS).until(() -> completed.size() == 2);
+            // session2 has no delay; it must complete while session1 is
+            // still blocked on the latch. This proves concurrent processing.
+            await().atMost(1000, MILLISECONDS).until(() -> completed.size() == 1);
+            Assertions.assertEquals(sid2, completed.get(0),
+                    "session2 should complete first (session1 is blocked)");
+
+            // Now release session1 and wait for both to be complete.
+            session1Release.countDown();
+            await().atMost(1000, MILLISECONDS).until(() -> completed.size() == 2);
+        } finally {
+            session1Release.countDown();
+        }
 
         Assertions.assertIterableEquals(List.of(sid1, sid2), started,
                 "Started serializations");
@@ -536,9 +554,9 @@ class SessionSerializerTest {
                 .assertIterableEquals(List.of(sid2, sid1),
                         infoList.stream().map(SessionInfo::getClusterKey)
                                 .collect(Collectors.toList()),
-                        "Started completed");
+                        "Sent sessions");
         Assertions.assertIterableEquals(List.of(sid2, sid1), completed,
-                "Started completed");
+                "Completed serializations");
 
         verify(connector, times(2)).markSerializationStarted(anyString(),
                 any());
@@ -964,6 +982,29 @@ class SessionSerializerTest {
                 lock.unlock();
             }
             return session;
+        }
+    }
+
+    // A serializable class that blocks serialization until an externally
+    // controlled latch is released. Used to make concurrency ordering
+    // deterministic in tests without relying on Thread.sleep timing.
+    private static class BlockingSerialization implements Serializable {
+        private final transient CountDownLatch release;
+
+        BlockingSerialization(CountDownLatch release) {
+            this.release = release;
+        }
+
+        @Serial
+        private void writeObject(java.io.ObjectOutputStream stream)
+                throws IOException {
+            stream.defaultWriteObject();
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandlerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/sessiontracker/serialization/debug/SerializationDebugRequestHandlerTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
@@ -305,14 +306,26 @@ class SerializationDebugRequestHandlerTest {
         properties.setTimeout(100);
         handler = new SerializationDebugRequestHandler(properties);
 
-        httpSession.setAttribute("OBJ1", new SlowSerialization());
+        // Block the serializer on a latch so that the 100ms timeout always
+        // fires before the serialization finishes, regardless of scheduling
+        // delays (e.g. GC pauses, slow CI runners). Without this, a long
+        // enough pause on the main thread between trySerialize() and
+        // waitForCompletion() can let the background serialization complete
+        // first, hiding the timeout outcome.
+        CountDownLatch releaseSerializer = new CountDownLatch(1);
+        SlowSerialization.releaseLatch = releaseSerializer;
+        try {
+            httpSession.setAttribute("OBJ1", new SlowSerialization());
 
-        runDebugTool();
-        Result result = resultHolder.get();
-        assertThat(result.getSessionId()).isEqualTo(httpSession.getId());
-        assertThat(result.getOutcomes()).containsExactlyInAnyOrder(
-                Outcome.NOT_SERIALIZABLE_CLASSES,
-                Outcome.SERIALIZATION_TIMEOUT);
+            runDebugTool();
+            Result result = resultHolder.get();
+            assertThat(result.getSessionId()).isEqualTo(httpSession.getId());
+            assertThat(result.getOutcomes()).containsExactlyInAnyOrder(
+                    Outcome.NOT_SERIALIZABLE_CLASSES,
+                    Outcome.SERIALIZATION_TIMEOUT);
+        } finally {
+            releaseSerializer.countDown();
+        }
     }
 
     @Test
@@ -382,10 +395,13 @@ class SerializationDebugRequestHandlerTest {
     }
 
     private static class SlowSerialization extends DeepNested {
+        static CountDownLatch releaseLatch;
+
         private void writeObject(ObjectOutputStream out) throws IOException {
             try {
-                Thread.sleep(2000);
+                releaseLatch.await();
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             }
             out.defaultWriteObject();


### PR DESCRIPTION
## Summary

Fixes a rare flake in `SerializationDebugRequestHandlerTest.handleRequest_serializationTimeout_timeoutReported` observed on CI (run [24824699112](https://github.com/vaadin/kubernetes-kit/actions/runs/24824699112)) where the test reported `[SERIALIZATION_FAILED, NOT_SERIALIZABLE_CLASSES]` instead of the expected `[NOT_SERIALIZABLE_CLASSES, SERIALIZATION_TIMEOUT]`.

## Root cause

The test had `SlowSerialization.writeObject` sleep 2000 ms and set the timeout to 100 ms. The expectation is that the 100 ms timeout fires first, producing `SERIALIZATION_TIMEOUT`.

The flow is:
1. Main thread: `trySerialize()` schedules async serialization, returns
2. Main thread: `waitForCompletion(100ms)` — awaits `serializationCompletedLatch`
3. Background: runs `Thread.sleep(2000)` then fails on non-serializable fields

If the main thread pauses (GC, JIT, loaded CI) for a couple of seconds between steps 1 and 2, the background task can reach its failure path and count the latch down via `whenSerialized.accept(null)` before the main thread enters `waitForCompletion`. The 100 ms `await` then returns immediately with `completed=true`, `timeout()` is never called, and only `SERIALIZATION_FAILED` ends up in the outcomes.

## Fix

Replace `Thread.sleep(2000)` with a test-controlled `CountDownLatch` that `writeObject` awaits unbounded. The test releases the latch in a `finally` block after asserting. This guarantees the latch stays uncounted until the assertion is done, so the 100 ms timeout always fires regardless of main-thread pauses.

## Test plan

- [x] `mvn test -Dtest=SerializationDebugRequestHandlerTest#handleRequest_serializationTimeout_timeoutReported` passes 5/5 runs locally
- [x] Full `SerializationDebugRequestHandlerTest` class (13 tests) passes