### PR TITLE
Replace pull_request_target with pull_request in CI workflows

### DIFF
--- a/.github/workflows/kubernetes-test.yml
+++ b/.github/workflows/kubernetes-test.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
   merge_group:
@@ -19,7 +19,7 @@ env:
   IMAGE_NAME: kubernetes-kit-demo:test
 jobs:
   kubernetes-test:
-    environment: ${{ github.event.pull_request.head.repo.fork && 'pr-tests' || '' }}
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     timeout-minutes: 45
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
   merge_group:
@@ -22,12 +22,13 @@ env:
   JAVA_VERSION: '21'
 jobs:
   tests:
-    environment: ${{ github.event.pull_request.head.repo.fork && 'pr-tests' || '' }}
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
       - run: echo "Concurrency Group = ${_HEAD_REF:-$_REF_NAME}"
       - name: Check secrets
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         env:
           VAADIN_PRO_KEY: ${{secrets.VAADIN_PRO_KEY}}
         run: |
@@ -75,7 +76,7 @@ jobs:
       issues: read
       checks: write
       pull-requests: write
-    if: ${{ always() }}
+    if: ${{ always() && !github.event.pull_request.head.repo.fork }}
     needs: [tests]
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## Summary

Replaces `pull_request_target` with `pull_request` in `validation.yml` and `kubernetes-test.yml`.

Removes `environment: pr-tests` gates from both workflows. All test jobs skip for fork PRs since `VAADIN_PRO_KEY` is not available in that context. `test-results` also skips for fork PRs to avoid artifact download failures.