### PR TITLE
feat: support multiple sticky session cookie names 

### DIFF
--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitConfiguration.java
@@ -69,7 +69,7 @@ public class KubernetesKitConfiguration {
     RollingUpdateHandler rollingUpdateHandler(
             KubernetesKitProperties properties) {
         return new RollingUpdateHandler(properties.getAppVersion(),
-                properties.getStickySessionCookieName(),
+                properties.getStickySessionCookieNames(),
                 properties.getUpdateVersionHeaderName());
     }
 

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitProperties.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitProperties.java
@@ -17,6 +17,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import com.vaadin.kubernetes.starter.sessiontracker.CurrentKey;
 import com.vaadin.kubernetes.starter.sessiontracker.SameSite;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 /**
  * Definition of configuration properties for the Kubernetes Kit starter.
@@ -294,10 +295,14 @@ public class KubernetesKitProperties {
      * @deprecated Use {@link #getStickySessionCookieNames()} instead to get
      *             all configured cookie names.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "3.1", forRemoval = true)
+    @DeprecatedConfigurationProperty(
+        since = "3.1", replacement = "vaadin.kubernetes.sticky-session-cookie-names",
+        reason = "Replaced by vaadin.kubernetes.sticky-session-cookie-names which accepts a list of cookie names."
+    )
     public String getStickySessionCookieName() {
-        return stickySessionCookieNames.isEmpty() ? null
-                : stickySessionCookieNames.get(0);
+        return stickySessionCookieNames == null || stickySessionCookieNames.isEmpty() ? null
+                : stickySessionCookieNames.getFirst();
     }
 
     /**
@@ -308,7 +313,7 @@ public class KubernetesKitProperties {
      *            the sticky session cookie names
      * @see #stickySessionCookieNames
      */
-    public void setStickySessionCookieName(
+    public void setStickySessionCookieNames(
             List<String> stickySessionCookieName) {
         this.stickySessionCookieNames = stickySessionCookieName;
     }
@@ -320,10 +325,10 @@ public class KubernetesKitProperties {
      * @param stickySessionCookieName
      *            the sticky session cookie name
      * @see #stickySessionCookieNames
-     * @deprecated Use {@link #setStickySessionCookieName(List)} instead to
+     * @deprecated Use {@link #setStickySessionCookieNames(List)} instead to
      *             support multiple cookie names.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "3.1", forRemoval = true)
     public void setStickySessionCookieName(String stickySessionCookieName) {
         this.stickySessionCookieNames = stickySessionCookieName != null
                 ? new ArrayList<>(List.of(stickySessionCookieName))

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitProperties.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitProperties.java
@@ -10,6 +10,8 @@
 package com.vaadin.kubernetes.starter;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -95,14 +97,21 @@ public class KubernetesKitProperties {
     private String appVersion = System.getenv("APP_VERSION");
 
     /**
-     * The name of the cookie used by the ingress controller or gateway
+     * The names of the cookies used by the ingress controller or gateway
      * implementation for sticky sessions (session affinity).
      * <p>
-     * This must match the cookie name used by the infrastructure routing
-     * traffic to the application. The cookie is removed by
-     * {@link com.vaadin.kubernetes.starter.ui.RollingUpdateHandler RollingUpdateHandler}
-     * when the user accepts a version switch, so that the next request is no
-     * longer pinned to the old pod.
+     * All cookies in the list are removed by
+     * {@link com.vaadin.kubernetes.starter.ui.RollingUpdateHandler
+     * RollingUpdateHandler} when the user accepts a version switch, so that the
+     * next request is no longer pinned to the old pod.
+     * <p>
+     * Multiple cookie names can be specified as a comma-separated list in the
+     * {@code VAADIN_KUBERNETES_STICKY_SESSION_COOKIE_NAME} environment variable
+     * or the {@code vaadin.kubernetes.sticky-session-cookie-name} property.
+     * This is useful when the gateway sets more than one affinity cookie — for
+     * example, Azure Application Gateway with AGIC sets both
+     * {@code ApplicationGatewayAffinity} and {@code ApplicationGatewayAffinityCORS}
+     * when cookie-based affinity is enabled.
      * <p>
      * For the Kubernetes Ingress API with NGINX Ingress, the default cookie
      * name {@code INGRESSCOOKIE} is used when session affinity is enabled via
@@ -116,7 +125,8 @@ public class KubernetesKitProperties {
      * implementation-specific cookie name that must be determined from the
      * implementation's documentation or by inspecting HTTP responses.
      */
-    private String stickySessionCookieName = "INGRESSCOOKIE";
+    private List<String> stickySessionCookieName = new ArrayList<>(
+            List.of("INGRESSCOOKIE"));
 
     /**
      * Checks if auto-configuration of Kubernetes Kit is
@@ -264,25 +274,26 @@ public class KubernetesKitProperties {
     }
 
     /**
-     * Gets the name of the cookie used by the ingress controller or gateway
+     * Gets the names of the cookies used by the ingress controller or gateway
      * implementation for sticky sessions.
      *
-     * @return the sticky session cookie name
+     * @return the sticky session cookie names
      * @see #stickySessionCookieName
      */
-    public String getStickySessionCookieName() {
+    public List<String> getStickySessionCookieName() {
         return stickySessionCookieName;
     }
 
     /**
-     * Sets the name of the cookie used by the ingress controller or gateway
+     * Sets the names of the cookies used by the ingress controller or gateway
      * implementation for sticky sessions.
      *
      * @param stickySessionCookieName
-     *            the sticky session cookie name
+     *            the sticky session cookie names
      * @see #stickySessionCookieName
      */
-    public void setStickySessionCookieName(String stickySessionCookieName) {
+    public void setStickySessionCookieName(
+            List<String> stickySessionCookieName) {
         this.stickySessionCookieName = stickySessionCookieName;
     }
 

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitProperties.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/KubernetesKitProperties.java
@@ -125,7 +125,7 @@ public class KubernetesKitProperties {
      * implementation-specific cookie name that must be determined from the
      * implementation's documentation or by inspecting HTTP responses.
      */
-    private List<String> stickySessionCookieName = new ArrayList<>(
+    private List<String> stickySessionCookieNames = new ArrayList<>(
             List.of("INGRESSCOOKIE"));
 
     /**
@@ -278,10 +278,26 @@ public class KubernetesKitProperties {
      * implementation for sticky sessions.
      *
      * @return the sticky session cookie names
-     * @see #stickySessionCookieName
+     * @see #stickySessionCookieNames
      */
-    public List<String> getStickySessionCookieName() {
-        return stickySessionCookieName;
+    public List<String> getStickySessionCookieNames() {
+        return stickySessionCookieNames;
+    }
+
+    /**
+     * Gets the name of the cookie used by the ingress controller or gateway
+     * implementation for sticky sessions.
+     *
+     * @return the first sticky session cookie name, or {@code null} if none
+     *         configured
+     * @see #stickySessionCookieNames
+     * @deprecated Use {@link #getStickySessionCookieNames()} instead to get
+     *             all configured cookie names.
+     */
+    @Deprecated(forRemoval = true)
+    public String getStickySessionCookieName() {
+        return stickySessionCookieNames.isEmpty() ? null
+                : stickySessionCookieNames.get(0);
     }
 
     /**
@@ -290,11 +306,28 @@ public class KubernetesKitProperties {
      *
      * @param stickySessionCookieName
      *            the sticky session cookie names
-     * @see #stickySessionCookieName
+     * @see #stickySessionCookieNames
      */
     public void setStickySessionCookieName(
             List<String> stickySessionCookieName) {
-        this.stickySessionCookieName = stickySessionCookieName;
+        this.stickySessionCookieNames = stickySessionCookieName;
+    }
+
+    /**
+     * Sets the name of the cookie used by the ingress controller or gateway
+     * implementation for sticky sessions.
+     *
+     * @param stickySessionCookieName
+     *            the sticky session cookie name
+     * @see #stickySessionCookieNames
+     * @deprecated Use {@link #setStickySessionCookieName(List)} instead to
+     *             support multiple cookie names.
+     */
+    @Deprecated(forRemoval = true)
+    public void setStickySessionCookieName(String stickySessionCookieName) {
+        this.stickySessionCookieNames = stickySessionCookieName != null
+                ? new ArrayList<>(List.of(stickySessionCookieName))
+                : new ArrayList<>();
     }
 
 }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/ui/ClusterSupport.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/ui/ClusterSupport.java
@@ -9,8 +9,6 @@
  */
 package com.vaadin.kubernetes.starter.ui;
 
-import java.util.List;
-
 import com.vaadin.kubernetes.starter.KubernetesKitProperties;
 
 /**
@@ -58,7 +56,7 @@ public class ClusterSupport extends RollingUpdateHandler {
     @Deprecated(forRemoval = true)
     @SuppressWarnings("deprecation")
     public ClusterSupport() {
-        super(System.getenv(ENV_APP_VERSION), List.of(STICKY_CLUSTER_COOKIE),
+        super(System.getenv(ENV_APP_VERSION), STICKY_CLUSTER_COOKIE,
                 UPDATE_VERSION_HEADER);
     }
 
@@ -75,7 +73,7 @@ public class ClusterSupport extends RollingUpdateHandler {
     @SuppressWarnings("deprecation")
     public ClusterSupport(String stickySessionCookieName,
             String updateVersionHeaderName) {
-        super(System.getenv(ENV_APP_VERSION), List.of(stickySessionCookieName),
+        super(System.getenv(ENV_APP_VERSION), stickySessionCookieName,
                 updateVersionHeaderName);
     }
 
@@ -93,8 +91,7 @@ public class ClusterSupport extends RollingUpdateHandler {
     @Deprecated(forRemoval = true)
     public ClusterSupport(String appVersion, String stickySessionCookieName,
             String updateVersionHeaderName) {
-        super(appVersion, List.of(stickySessionCookieName),
-                updateVersionHeaderName);
+        super(appVersion, stickySessionCookieName, updateVersionHeaderName);
     }
 
 }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/ui/ClusterSupport.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/ui/ClusterSupport.java
@@ -9,6 +9,8 @@
  */
 package com.vaadin.kubernetes.starter.ui;
 
+import java.util.List;
+
 import com.vaadin.kubernetes.starter.KubernetesKitProperties;
 
 /**
@@ -56,7 +58,7 @@ public class ClusterSupport extends RollingUpdateHandler {
     @Deprecated(forRemoval = true)
     @SuppressWarnings("deprecation")
     public ClusterSupport() {
-        super(System.getenv(ENV_APP_VERSION), STICKY_CLUSTER_COOKIE,
+        super(System.getenv(ENV_APP_VERSION), List.of(STICKY_CLUSTER_COOKIE),
                 UPDATE_VERSION_HEADER);
     }
 
@@ -73,7 +75,7 @@ public class ClusterSupport extends RollingUpdateHandler {
     @SuppressWarnings("deprecation")
     public ClusterSupport(String stickySessionCookieName,
             String updateVersionHeaderName) {
-        super(System.getenv(ENV_APP_VERSION), stickySessionCookieName,
+        super(System.getenv(ENV_APP_VERSION), List.of(stickySessionCookieName),
                 updateVersionHeaderName);
     }
 
@@ -91,7 +93,8 @@ public class ClusterSupport extends RollingUpdateHandler {
     @Deprecated(forRemoval = true)
     public ClusterSupport(String appVersion, String stickySessionCookieName,
             String updateVersionHeaderName) {
-        super(appVersion, stickySessionCookieName, updateVersionHeaderName);
+        super(appVersion, List.of(stickySessionCookieName),
+                updateVersionHeaderName);
     }
 
 }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/ui/RollingUpdateHandler.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/ui/RollingUpdateHandler.java
@@ -76,15 +76,48 @@ public class RollingUpdateHandler implements VaadinServiceInitListener {
      *            controller or gateway sets this header on requests to the
      *            current version with the new version as its value.
      * @see KubernetesKitProperties#getAppVersion()
-     * @see KubernetesKitProperties#getStickySessionCookieName()
+     * @see KubernetesKitProperties#getStickySessionCookieNames()
      * @see KubernetesKitProperties#getUpdateVersionHeaderName()
      */
     public RollingUpdateHandler(String appVersion,
             List<String> stickySessionCookieNames,
             String updateVersionHeaderName) {
         this.appVersion = appVersion;
-        this.stickySessionCookieNames = stickySessionCookieNames;
+        this.stickySessionCookieNames = stickySessionCookieNames != null
+                ? stickySessionCookieNames
+                : List.of();
         this.updateVersionHeaderName = updateVersionHeaderName;
+    }
+
+    /**
+     * Creates a new {@code RollingUpdateHandler} instance with a single sticky
+     * session cookie name.
+     *
+     * @param appVersion
+     *            the application version. When the update version header value
+     *            differs from this version, a notification is shown prompting
+     *            the user to switch to the new version. If {@code null},
+     *            rolling update version detection is disabled.
+     * @param stickySessionCookieName
+     *            the name of the cookie used by the ingress controller or
+     *            gateway implementation for sticky sessions.
+     * @param updateVersionHeaderName
+     *            the name of the HTTP request header used to detect a new
+     *            application version during rolling updates.
+     * @see KubernetesKitProperties#getAppVersion()
+     * @see KubernetesKitProperties#getStickySessionCookieNames()
+     * @see KubernetesKitProperties#getUpdateVersionHeaderName()
+     * @deprecated Use {@link #RollingUpdateHandler(String, List, String)}
+     *             instead to support multiple sticky session cookie names.
+     */
+    @Deprecated(forRemoval = true)
+    public RollingUpdateHandler(String appVersion,
+            String stickySessionCookieName, String updateVersionHeaderName) {
+        this(appVersion,
+                stickySessionCookieName != null
+                        ? List.of(stickySessionCookieName)
+                        : List.of(),
+                updateVersionHeaderName);
     }
 
     /**
@@ -179,8 +212,8 @@ public class RollingUpdateHandler implements VaadinServiceInitListener {
 
     private void removeStickyClusterCookie() {
         VaadinResponse response = VaadinResponse.getCurrent();
+        LOGGER.debug("Removing cookies: {}.", stickySessionCookieNames);
         for (String name : stickySessionCookieNames) {
-            LOGGER.debug("Removing cookie '{}'.", name);
             Cookie cookie = new Cookie(name, "");
             cookie.setMaxAge(0);
             response.addCookie(cookie);

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/ui/RollingUpdateHandler.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/ui/RollingUpdateHandler.java
@@ -11,6 +11,7 @@ package com.vaadin.kubernetes.starter.ui;
 
 import jakarta.servlet.http.Cookie;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -50,7 +51,7 @@ public class RollingUpdateHandler implements VaadinServiceInitListener {
 
     private final String updateVersionHeaderName;
 
-    private final String stickySessionCookieName;
+    private final List<String> stickySessionCookieNames;
 
     private SwitchVersionListener switchVersionListener;
 
@@ -62,13 +63,13 @@ public class RollingUpdateHandler implements VaadinServiceInitListener {
      *            differs from this version, a notification is shown prompting
      *            the user to switch to the new version. If {@code null},
      *            rolling update version detection is disabled.
-     * @param stickySessionCookieName
-     *            the name of the cookie used by the ingress controller or
-     *            gateway implementation for sticky sessions. This must match
-     *            the cookie name configured in the infrastructure routing
-     *            traffic to the application. When the user accepts a version
-     *            switch, this cookie is removed so that the next request is no
-     *            longer pinned to the old pod.
+     * @param stickySessionCookieNames
+     *            the names of the cookies used by the ingress controller or
+     *            gateway implementation for sticky sessions. All cookies in the
+     *            list are removed when the user accepts a version switch, so
+     *            that the next request is no longer pinned to the old pod.
+     *            Multiple names are needed when the gateway sets more than one
+     *            affinity cookie (e.g. Azure Application Gateway with AGIC).
      * @param updateVersionHeaderName
      *            the name of the HTTP request header used to detect a new
      *            application version during rolling updates. The ingress
@@ -79,9 +80,10 @@ public class RollingUpdateHandler implements VaadinServiceInitListener {
      * @see KubernetesKitProperties#getUpdateVersionHeaderName()
      */
     public RollingUpdateHandler(String appVersion,
-            String stickySessionCookieName, String updateVersionHeaderName) {
+            List<String> stickySessionCookieNames,
+            String updateVersionHeaderName) {
         this.appVersion = appVersion;
-        this.stickySessionCookieName = stickySessionCookieName;
+        this.stickySessionCookieNames = stickySessionCookieNames;
         this.updateVersionHeaderName = updateVersionHeaderName;
     }
 
@@ -176,10 +178,13 @@ public class RollingUpdateHandler implements VaadinServiceInitListener {
     }
 
     private void removeStickyClusterCookie() {
-        LOGGER.debug("Removing cookie '{}'.", stickySessionCookieName);
-        Cookie cookie = new Cookie(stickySessionCookieName, "");
-        cookie.setMaxAge(0);
-        VaadinResponse.getCurrent().addCookie(cookie);
+        VaadinResponse response = VaadinResponse.getCurrent();
+        for (String name : stickySessionCookieNames) {
+            LOGGER.debug("Removing cookie '{}'.", name);
+            Cookie cookie = new Cookie(name, "");
+            cookie.setMaxAge(0);
+            response.addCookie(cookie);
+        }
     }
 
 }

--- a/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/ui/RollingUpdateHandler.java
+++ b/kubernetes-kit-starter/src/main/java/com/vaadin/kubernetes/starter/ui/RollingUpdateHandler.java
@@ -211,6 +211,9 @@ public class RollingUpdateHandler implements VaadinServiceInitListener {
     }
 
     private void removeStickyClusterCookie() {
+        if (stickySessionCookieNames == null || stickySessionCookieNames.isEmpty()) {
+            return;
+        }
         VaadinResponse response = VaadinResponse.getCurrent();
         LOGGER.debug("Removing cookies: {}.", stickySessionCookieNames);
         for (String name : stickySessionCookieNames) {

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/ui/RollingUpdateHandlerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/ui/RollingUpdateHandlerTest.java
@@ -255,32 +255,24 @@ public class RollingUpdateHandlerTest {
 
     @Test
     void onComponentEvent_usesConfiguredCookieName() throws IOException {
-        String customCookieName = "my-gateway-cookie";
-        RollingUpdateHandler customHandler = new RollingUpdateHandler("1.0.0",
-                List.of(customCookieName), "X-AppUpdate");
-        SwitchVersionListener switchVersionListener = mock(
-                SwitchVersionListener.class);
-        when(switchVersionListener.nodeSwitch(any(), any())).thenReturn(true);
-        customHandler.setSwitchVersionListener(switchVersionListener);
-
-        List<Cookie> cookies = triggerSwitchVersionEvent(customHandler);
-
-        assertEquals(1, cookies.size());
-        assertEquals(customCookieName, cookies.get(0).getName());
+        assertConfiguredCookiesExpired("my-gateway-cookie");
     }
 
     @Test
     void onComponentEvent_expiresAllConfiguredCookieNames() throws IOException {
-        String cookieName1 = "ApplicationGatewayAffinity";
-        String cookieName2 = "ApplicationGatewayAffinityCORS";
+        assertConfiguredCookiesExpired("ApplicationGatewayAffinity", "ApplicationGatewayAffinityCORS");
+    }
+
+    private void assertConfiguredCookiesExpired(String... cookieNames) throws IOException {
+        List<String> cookieNamesList = List.of(cookieNames);
         RollingUpdateHandler customHandler = new RollingUpdateHandler("1.0.0",
-                List.of(cookieName1, cookieName2), "X-AppUpdate");
+                cookieNamesList, "X-AppUpdate");
 
         List<Cookie> cookies = triggerSwitchVersionEvent(customHandler);
 
         List<String> expiredNames = cookies.stream().map(Cookie::getName)
                 .toList();
-        assertEquals(List.of(cookieName1, cookieName2), expiredNames);
+        assertEquals(cookieNamesList, expiredNames);
         cookies.forEach(c -> assertEquals(0, c.getMaxAge()));
     }
 

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/ui/RollingUpdateHandlerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/ui/RollingUpdateHandlerTest.java
@@ -34,6 +34,7 @@ import jakarta.servlet.http.Cookie;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
@@ -257,45 +258,15 @@ public class RollingUpdateHandlerTest {
         String customCookieName = "my-gateway-cookie";
         RollingUpdateHandler customHandler = new RollingUpdateHandler("1.0.0",
                 List.of(customCookieName), "X-AppUpdate");
-        WrappedSession wrappedSession = mock(WrappedSession.class);
-        UI ui = mock(UI.class);
-        VersionNotifier.SwitchVersionEvent switchVersionEvent = mock(
-                VersionNotifier.SwitchVersionEvent.class);
         SwitchVersionListener switchVersionListener = mock(
                 SwitchVersionListener.class);
-        ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor
-                .forClass(Cookie.class);
-
-        when(vaadinRequest.getHeader("X-AppUpdate")).thenReturn("2.0.0");
-        vaadinRequestMockedStatic.when(VaadinRequest::getCurrent)
-                .thenReturn(vaadinRequest);
-        vaadinResponseMockedStatic.when(VaadinResponse::getCurrent)
-                .thenReturn(vaadinResponse);
-        when(vaadinRequest.getWrappedSession()).thenReturn(wrappedSession);
-        when(vaadinSession.getSession()).thenReturn(wrappedSession);
-        when(vaadinSession.getUIs()).thenReturn(Collections.singletonList(ui));
-        when(ui.getChildren()).thenReturn(Stream.empty());
         when(switchVersionListener.nodeSwitch(any(), any())).thenReturn(true);
-
         customHandler.setSwitchVersionListener(switchVersionListener);
-        customHandler.serviceInit(serviceInitEvent);
 
-        verify(serviceInitEvent)
-                .addRequestHandler(requestHandlerArgCaptor.capture());
-        requestHandlerArgCaptor.getValue().handleRequest(vaadinSession,
-                vaadinRequest, vaadinResponse);
-        try (MockedConstruction<VersionNotifier> mockedVersionNotifier = mockConstruction(
-                VersionNotifier.class)) {
-            verify(vaadinSession).access(commandArgCaptor.capture());
-            commandArgCaptor.getValue().execute();
-            verify(mockedVersionNotifier.constructed().get(0))
-                    .addSwitchVersionEventListener(
-                            componentEventListenerArgCaptor.capture());
-            componentEventListenerArgCaptor.getValue()
-                    .onComponentEvent(switchVersionEvent);
-        }
-        verify(vaadinResponse).addCookie(cookieCaptor.capture());
-        assertEquals(customCookieName, cookieCaptor.getValue().getName());
+        List<Cookie> cookies = triggerSwitchVersionEvent(customHandler);
+
+        assertEquals(1, cookies.size());
+        assertEquals(customCookieName, cookies.get(0).getName());
     }
 
     @Test
@@ -304,6 +275,17 @@ public class RollingUpdateHandlerTest {
         String cookieName2 = "ApplicationGatewayAffinityCORS";
         RollingUpdateHandler customHandler = new RollingUpdateHandler("1.0.0",
                 List.of(cookieName1, cookieName2), "X-AppUpdate");
+
+        List<Cookie> cookies = triggerSwitchVersionEvent(customHandler);
+
+        List<String> expiredNames = cookies.stream().map(Cookie::getName)
+                .toList();
+        assertEquals(List.of(cookieName1, cookieName2), expiredNames);
+        cookies.forEach(c -> assertEquals(0, c.getMaxAge()));
+    }
+
+    private List<Cookie> triggerSwitchVersionEvent(
+            RollingUpdateHandler handlerToTest) throws IOException {
         WrappedSession wrappedSession = mock(WrappedSession.class);
         UI ui = mock(UI.class);
         VersionNotifier.SwitchVersionEvent switchVersionEvent = mock(
@@ -321,7 +303,7 @@ public class RollingUpdateHandlerTest {
         when(vaadinSession.getUIs()).thenReturn(Collections.singletonList(ui));
         when(ui.getChildren()).thenReturn(Stream.empty());
 
-        customHandler.serviceInit(serviceInitEvent);
+        handlerToTest.serviceInit(serviceInitEvent);
 
         verify(serviceInitEvent)
                 .addRequestHandler(requestHandlerArgCaptor.capture());
@@ -337,12 +319,8 @@ public class RollingUpdateHandlerTest {
             componentEventListenerArgCaptor.getValue()
                     .onComponentEvent(switchVersionEvent);
         }
-        verify(vaadinResponse, times(2)).addCookie(cookieCaptor.capture());
-        List<String> expiredNames = cookieCaptor.getAllValues().stream()
-                .map(Cookie::getName).toList();
-        assertEquals(List.of(cookieName1, cookieName2), expiredNames);
-        cookieCaptor.getAllValues()
-                .forEach(c -> assertEquals(0, c.getMaxAge()));
+        verify(vaadinResponse, atLeastOnce()).addCookie(cookieCaptor.capture());
+        return cookieCaptor.getAllValues();
     }
 
     @ParameterizedTest(name = "{index} And_IfNodeSwitchIs_{0}_doAppCleanupIsCalled_{1}_times")

--- a/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/ui/RollingUpdateHandlerTest.java
+++ b/kubernetes-kit-starter/src/test/java/com/vaadin/kubernetes/starter/ui/RollingUpdateHandlerTest.java
@@ -2,6 +2,7 @@ package com.vaadin.kubernetes.starter.ui;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -67,8 +68,8 @@ public class RollingUpdateHandlerTest {
 
     @BeforeEach
     void setUp() {
-        handler = new RollingUpdateHandler("1.0.0", "INGRESSCOOKIE",
-                "X-AppUpdate");
+        handler = new RollingUpdateHandler("1.0.0",
+                List.of("INGRESSCOOKIE"), "X-AppUpdate");
         currentInstanceMockedStatic = mockStatic(CurrentInstance.class);
         vaadinRequestMockedStatic = mockStatic(VaadinRequest.class);
         vaadinResponseMockedStatic = mockStatic(VaadinResponse.class);
@@ -93,7 +94,7 @@ public class RollingUpdateHandlerTest {
     @Test
     void serviceInit_withNoAppVersion_requestHandlerIsNotAdded() {
         RollingUpdateHandler noVersionHandler = new RollingUpdateHandler(null,
-                "INGRESSCOOKIE", "X-AppUpdate");
+                List.of("INGRESSCOOKIE"), "X-AppUpdate");
         ServiceInitEvent serviceInitEvent = mock(ServiceInitEvent.class);
 
         noVersionHandler.serviceInit(serviceInitEvent);
@@ -229,7 +230,7 @@ public class RollingUpdateHandlerTest {
     void handleRequest_usesConfiguredHeaderName() throws IOException {
         String customHeader = "X-AppVersion";
         RollingUpdateHandler customHandler = new RollingUpdateHandler("1.0.0",
-                "INGRESSCOOKIE", customHeader);
+                List.of("INGRESSCOOKIE"), customHeader);
         WrappedSession wrappedSession = mock(WrappedSession.class);
         UI ui = mock(UI.class);
 
@@ -255,7 +256,7 @@ public class RollingUpdateHandlerTest {
     void onComponentEvent_usesConfiguredCookieName() throws IOException {
         String customCookieName = "my-gateway-cookie";
         RollingUpdateHandler customHandler = new RollingUpdateHandler("1.0.0",
-                customCookieName, "X-AppUpdate");
+                List.of(customCookieName), "X-AppUpdate");
         WrappedSession wrappedSession = mock(WrappedSession.class);
         UI ui = mock(UI.class);
         VersionNotifier.SwitchVersionEvent switchVersionEvent = mock(
@@ -295,6 +296,53 @@ public class RollingUpdateHandlerTest {
         }
         verify(vaadinResponse).addCookie(cookieCaptor.capture());
         assertEquals(customCookieName, cookieCaptor.getValue().getName());
+    }
+
+    @Test
+    void onComponentEvent_expiresAllConfiguredCookieNames() throws IOException {
+        String cookieName1 = "ApplicationGatewayAffinity";
+        String cookieName2 = "ApplicationGatewayAffinityCORS";
+        RollingUpdateHandler customHandler = new RollingUpdateHandler("1.0.0",
+                List.of(cookieName1, cookieName2), "X-AppUpdate");
+        WrappedSession wrappedSession = mock(WrappedSession.class);
+        UI ui = mock(UI.class);
+        VersionNotifier.SwitchVersionEvent switchVersionEvent = mock(
+                VersionNotifier.SwitchVersionEvent.class);
+        ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor
+                .forClass(Cookie.class);
+
+        when(vaadinRequest.getHeader("X-AppUpdate")).thenReturn("2.0.0");
+        vaadinRequestMockedStatic.when(VaadinRequest::getCurrent)
+                .thenReturn(vaadinRequest);
+        vaadinResponseMockedStatic.when(VaadinResponse::getCurrent)
+                .thenReturn(vaadinResponse);
+        when(vaadinRequest.getWrappedSession()).thenReturn(wrappedSession);
+        when(vaadinSession.getSession()).thenReturn(wrappedSession);
+        when(vaadinSession.getUIs()).thenReturn(Collections.singletonList(ui));
+        when(ui.getChildren()).thenReturn(Stream.empty());
+
+        customHandler.serviceInit(serviceInitEvent);
+
+        verify(serviceInitEvent)
+                .addRequestHandler(requestHandlerArgCaptor.capture());
+        requestHandlerArgCaptor.getValue().handleRequest(vaadinSession,
+                vaadinRequest, vaadinResponse);
+        try (MockedConstruction<VersionNotifier> mockedVersionNotifier = mockConstruction(
+                VersionNotifier.class)) {
+            verify(vaadinSession).access(commandArgCaptor.capture());
+            commandArgCaptor.getValue().execute();
+            verify(mockedVersionNotifier.constructed().get(0))
+                    .addSwitchVersionEventListener(
+                            componentEventListenerArgCaptor.capture());
+            componentEventListenerArgCaptor.getValue()
+                    .onComponentEvent(switchVersionEvent);
+        }
+        verify(vaadinResponse, times(2)).addCookie(cookieCaptor.capture());
+        List<String> expiredNames = cookieCaptor.getAllValues().stream()
+                .map(Cookie::getName).toList();
+        assertEquals(List.of(cookieName1, cookieName2), expiredNames);
+        cookieCaptor.getAllValues()
+                .forEach(c -> assertEquals(0, c.getMaxAge()));
     }
 
     @ParameterizedTest(name = "{index} And_IfNodeSwitchIs_{0}_doAppCleanupIsCalled_{1}_times")


### PR DESCRIPTION
Fixes #285.

`VAADIN_KUBERNETES_STICKY_SESSION_COOKIE_NAME` (and the `vaadin.kubernetes.sticky-session-cookie-name` property) now accept a comma-separated list of cookie names. Every cookie in the list is expired when Kit triggers the affinity release on version switch.

**Example configuration for Azure Application Gateway + AGIC:**
```properties
VAADIN_KUBERNETES_STICKY_SESSION_COOKIE_NAME=ApplicationGatewayAffinity,ApplicationGatewayAffinityCORS
```

**Changes**

- `KubernetesKitProperties`: `stickySessionCookieName` changed from `String` to `List<String>`. Spring Boot's relaxed binding handles comma-separated values for `List` properties natively — both `.properties` files and OS environment variables work without custom parsing.
- `RollingUpdateHandler`: constructor updated to accept `List<String>`; `removeStickyClusterCookie()` now iterates and expires each cookie in the list.
- `ClusterSupport` (deprecated): `super(...)` calls updated to wrap the single-`String` argument in `List.of(...)` to match the new constructor signature.

**Backwards compatibility**

The default value remains `["INGRESSCOOKIE"]`. Existing single-cookie deployments require no configuration changes.

**Tests**

- `KubernetesKitPropertiesTest` — four binding tests: default value, single-value `.properties` binding, comma-separated `.properties` binding, and comma-separated environment variable binding (`SystemEnvironmentPropertySource` faithfully simulates OS env var name mapping).
- `RollingUpdateHandlerTest` — updated existing tests for the new constructor signature; new `onComponentEvent_expiresAllConfiguredCookieNames` test verifies both `ApplicationGatewayAffinity` and `ApplicationGatewayAffinityCORS` are each expired with `maxAge=0` on version switch.
